### PR TITLE
Stricter rules for arc angles

### DIFF
--- a/mobius/Cargo.toml
+++ b/mobius/Cargo.toml
@@ -10,3 +10,6 @@ svg = "0.18.0"
 [dev-dependencies]
 test-case = "3.3.1"
 pretty_assertions = "1.4.1"
+
+[features]
+debug_cline_arcs = []

--- a/mobius/examples/candy_corn.rs
+++ b/mobius/examples/candy_corn.rs
@@ -6,14 +6,13 @@ use std::{
 use abstraction::Group;
 use mobius::{
     algorithms::{GridIFS, SemigroupIFS},
-    geometry::Circle,
     hyperbolic,
     hyperbolic_tilings::{corner_rotation_group, get_fundamental_region, reflection_group},
     motifs::candy_corn,
     rendering::Style,
     rotation, scale,
     svg_plot::{render_views, style_geometry, style_motif, style_motifs, union, View},
-    transformable::{Cline, ClineTile, Motif, Transformable},
+    transformable::{Motif, Transformable},
     translation, Complex, Mobius,
 };
 
@@ -68,15 +67,11 @@ pub fn main() -> Result<(), Error> {
     //let warped_pair = two_corns.transform(pull_left);
     let curved_wallpaper = curved_grid.apply(&two_corns);
     let curved_svg = style_motifs(&curved_wallpaper[..], &styles);
-    let unit_circle = style_geometry(
-        Style::stroke(255, 255, 255).with_width(0.5),
-        &ClineTile::new(vec![Cline::unit_circle()]),
-    );
     render_views(
         "output",
         "candy_corn_warpedpaper",
         &[View("", -2.5, 3.0, 4.0)],
-        union(vec![/*unit_circle, */ curved_svg]),
+        curved_svg,
     )?;
 
     // Candy-corner hyperbolic tiling, based on tiling {3, 7}
@@ -84,13 +79,11 @@ pub fn main() -> Result<(), Error> {
     let dist_to_edge = 0.5 * (e2_conj * Complex::Zero).real();
     println!("{}", dist_to_edge);
     let shrink = scale(dist_to_edge * 0.3).unwrap();
-    let rot2 = rotation(PI).unwrap();
     let shift = translation(Complex::new(0.51 * dist_to_edge, 0.05)).unwrap();
     let tiny_corn = corn.transform(shift * shrink);
     let ifs = SemigroupIFS::new(vec![conj, r_conj, e2_conj]);
     let candy_corners = ifs.apply(&tiny_corn, 0, 7);
-    let (fundamental_triangle, (center, edge_midpoint, vertex)) =
-        get_fundamental_region(3, 7).unwrap();
+    let (fundamental_triangle, (_, _, vertex)) = get_fundamental_region(3, 7).unwrap();
     let tiles = ifs.apply(&fundamental_triangle, 0, 5);
     let yellow_lines = Style::stroke(255, 0, 255).with_width(0.5);
 

--- a/mobius/examples/candy_corn.rs
+++ b/mobius/examples/candy_corn.rs
@@ -77,7 +77,6 @@ pub fn main() -> Result<(), Error> {
     // Candy-corner hyperbolic tiling, based on tiling {3, 7}
     let (conj, r_conj, e2_conj) = reflection_group(3, 7).unwrap();
     let dist_to_edge = 0.5 * (e2_conj * Complex::Zero).real();
-    println!("{}", dist_to_edge);
     let shrink = scale(dist_to_edge * 0.3).unwrap();
     let shift = translation(Complex::new(0.51 * dist_to_edge, 0.05)).unwrap();
     let tiny_corn = corn.transform(shift * shrink);

--- a/mobius/examples/crinkle_arc.rs
+++ b/mobius/examples/crinkle_arc.rs
@@ -53,10 +53,11 @@ fn arc_lerp(circle: Circle, a: Complex, b: Complex, t: f64) -> Complex {
 
 fn arc_fractal(arc: CircularArc) -> (Mobius, Mobius) {
     let CircularArc { circle, angles } = arc;
-    let ArcAngles(angle_a, angle_b, angle_c) = angles;
-    let t = ((angle_b - angle_a) / (angle_c - angle_a)).abs();
+    let ArcAngles(angle_a, angle_c) = angles;
+    let t = 0.5;
 
     let a = circle.get_point(angle_a);
+    let angle_b = t * (angle_a + angle_c);
     let b = circle.get_point(angle_b);
     let c = circle.get_point(angle_c);
 
@@ -73,7 +74,7 @@ fn arc_fractal(arc: CircularArc) -> (Mobius, Mobius) {
 }
 
 fn main() -> Result<(), Error> {
-    let angles = ArcAngles::new(0.0, PI / 4.0, PI / 2.0).unwrap();
+    let angles = ArcAngles::new(0.0, PI / 2.0).unwrap();
     let arc = CircularArc::new(Circle::unit_circle(), angles);
     let (a, b) = arc_fractal(arc);
 

--- a/mobius/examples/crinkle_arc.rs
+++ b/mobius/examples/crinkle_arc.rs
@@ -3,7 +3,7 @@ use std::{
     io::Error,
 };
 
-use mobius::{algorithms::SemigroupIFS, transformable::Cline};
+use mobius::{algorithms::SemigroupIFS, geometry::ArcAngles, transformable::Cline};
 use mobius::{
     cline_arc::ClineArc,
     geometry::{Circle, CircularArc},
@@ -52,12 +52,8 @@ fn arc_lerp(circle: Circle, a: Complex, b: Complex, t: f64) -> Complex {
 }
 
 fn arc_fractal(arc: CircularArc) -> (Mobius, Mobius) {
-    let CircularArc {
-        circle,
-        angle_a,
-        angle_b,
-        angle_c,
-    } = arc;
+    let CircularArc { circle, angles } = arc;
+    let ArcAngles(angle_a, angle_b, angle_c) = angles;
     let t = ((angle_b - angle_a) / (angle_c - angle_a)).abs();
 
     let a = circle.get_point(angle_a);
@@ -77,7 +73,8 @@ fn arc_fractal(arc: CircularArc) -> (Mobius, Mobius) {
 }
 
 fn main() -> Result<(), Error> {
-    let arc = CircularArc::new(Circle::unit_circle(), 0.0, PI / 4.0, PI / 2.0);
+    let angles = ArcAngles::new(0.0, PI / 4.0, PI / 2.0).unwrap();
+    let arc = CircularArc::new(Circle::unit_circle(), angles);
     let (a, b) = arc_fractal(arc);
 
     let tile: ClineArc = arc.into();

--- a/mobius/examples/ghost_tour.rs
+++ b/mobius/examples/ghost_tour.rs
@@ -56,8 +56,6 @@ pub fn main() -> Result<(), std::io::Error> {
     )
     .unwrap();
 
-    println!("{}", Mobius::commutator(left_parabolic, right_parabolic));
-
     let parabolic_ifs = GroupIFS::new(vec![left_parabolic, right_parabolic]);
     let parabolic_walk = parabolic_ifs.apply(&small_ghost, 0, 5);
     render_views(

--- a/mobius/examples/mobius_sierpinski.rs
+++ b/mobius/examples/mobius_sierpinski.rs
@@ -1,7 +1,7 @@
-use core::f64;
+use std::f64::consts::PI;
 
 use mobius::{
-    geometry::{Circle, CircularArc, LineSegment},
+    geometry::{ArcAngles, Circle, CircularArc, LineSegment},
     scale,
     svg_plot::{add_geometry, flip_y, make_axes, make_card},
     transformable::{Cline, ClineArcTile, ClineTile, Transformable},
@@ -151,15 +151,10 @@ fn main() {
 
     // ----------------------
 
+    let quarter_circle = ArcAngles::new(0.0, PI / 4.0, PI / 2.0).unwrap();
     let tile = ClineArcTile::new(vec![
         LineSegment::new(Complex::Zero, Complex::ONE).into(),
-        CircularArc::new(
-            Circle::unit_circle(),
-            0.0,
-            f64::consts::FRAC_PI_4,
-            f64::consts::FRAC_PI_2,
-        )
-        .into(),
+        CircularArc::new(Circle::unit_circle(), quarter_circle).into(),
         LineSegment::new(Complex::I, Complex::Zero).into(),
     ]);
 

--- a/mobius/examples/mobius_sierpinski.rs
+++ b/mobius/examples/mobius_sierpinski.rs
@@ -151,7 +151,7 @@ fn main() {
 
     // ----------------------
 
-    let quarter_circle = ArcAngles::new(0.0, PI / 4.0, PI / 2.0).unwrap();
+    let quarter_circle = ArcAngles::new(0.0, PI / 2.0).unwrap();
     let tile = ClineArcTile::new(vec![
         LineSegment::new(Complex::Zero, Complex::ONE).into(),
         CircularArc::new(Circle::unit_circle(), quarter_circle).into(),

--- a/mobius/examples/nacho.rs
+++ b/mobius/examples/nacho.rs
@@ -5,7 +5,7 @@ use std::{
 
 use mobius::{
     algorithms::SemigroupIFS,
-    geometry::{Circle, CircularArc, LineSegment},
+    geometry::{ArcAngles, Circle, CircularArc, LineSegment},
     map_triple,
     rendering::Style,
     scale,
@@ -63,9 +63,10 @@ fn main() -> Result<(), Error> {
     let xforms = compute_xforms();
     let modified_sierpinski = SemigroupIFS::new(xforms.clone());
 
+    let angles = ArcAngles::new(0.0, FRAC_PI_4, FRAC_PI_2).unwrap();
     let tile = ClineArcTile::new(vec![
         LineSegment::new(Complex::Zero, Complex::ONE).into(),
-        CircularArc::new(Circle::unit_circle(), 0.0, FRAC_PI_4, FRAC_PI_2).into(),
+        CircularArc::new(Circle::unit_circle(), angles).into(),
         LineSegment::new(Complex::I, Complex::Zero).into(),
     ]);
 

--- a/mobius/examples/nacho.rs
+++ b/mobius/examples/nacho.rs
@@ -1,7 +1,4 @@
-use std::{
-    f64::consts::{FRAC_PI_2, FRAC_PI_4},
-    io::Error,
-};
+use std::{f64::consts::FRAC_PI_2, io::Error};
 
 use mobius::{
     algorithms::SemigroupIFS,
@@ -63,7 +60,7 @@ fn main() -> Result<(), Error> {
     let xforms = compute_xforms();
     let modified_sierpinski = SemigroupIFS::new(xforms.clone());
 
-    let angles = ArcAngles::new(0.0, FRAC_PI_4, FRAC_PI_2).unwrap();
+    let angles = ArcAngles::new(0.0, FRAC_PI_2).unwrap();
     let tile = ClineArcTile::new(vec![
         LineSegment::new(Complex::Zero, Complex::ONE).into(),
         CircularArc::new(Circle::unit_circle(), angles).into(),

--- a/mobius/examples/three_lenses.rs
+++ b/mobius/examples/three_lenses.rs
@@ -56,7 +56,7 @@ fn show_individual_xforms(
 fn main() {
     let xforms = make_xforms();
 
-    let angles = ArcAngles::new(0.0, PI / 2.0, PI).unwrap();
+    let angles = ArcAngles::new(0.0, PI).unwrap();
     let half_circle = ClineArcTile::new(vec![
         LineSegment::new(-Complex::ONE, Complex::ONE).into(),
         CircularArc::new(Circle::unit_circle(), angles).into(),

--- a/mobius/examples/three_lenses.rs
+++ b/mobius/examples/three_lenses.rs
@@ -1,8 +1,8 @@
-use std::f64::consts::{FRAC_PI_2, PI};
+use std::f64::consts::PI;
 
 use mobius::{
     algorithms::SemigroupIFS,
-    geometry::{Circle, CircularArc, LineSegment},
+    geometry::{ArcAngles, Circle, CircularArc, LineSegment},
     map_triple,
     rendering::Style,
     svg_plot::{flip_y, make_card, style_geometry},
@@ -56,9 +56,10 @@ fn show_individual_xforms(
 fn main() {
     let xforms = make_xforms();
 
+    let angles = ArcAngles::new(0.0, PI / 2.0, PI).unwrap();
     let half_circle = ClineArcTile::new(vec![
         LineSegment::new(-Complex::ONE, Complex::ONE).into(),
-        CircularArc::new(Circle::unit_circle(), 0.0, FRAC_PI_2, PI).into(),
+        CircularArc::new(Circle::unit_circle(), angles).into(),
     ]);
 
     //let rotate_90 = rotation(FRAC_PI_2).unwrap();

--- a/mobius/examples/tricorn.rs
+++ b/mobius/examples/tricorn.rs
@@ -1,8 +1,7 @@
-use core::f64;
-use std::f64::consts::{FRAC_PI_2, FRAC_PI_4, TAU};
+use std::f64::consts::{FRAC_PI_2, FRAC_PI_4, PI, TAU};
 
 use mobius::{
-    geometry::{Circle, CircularArc, LineSegment},
+    geometry::{ArcAngles, Circle, CircularArc, LineSegment},
     map_triple, scale,
     svg_plot::{add_geometry, flip_y, make_axes, make_card},
     transformable::{ClineArcTile, Transformable},
@@ -60,15 +59,10 @@ fn main() {
 
     // ----------------------
 
+    let angles = ArcAngles::new(0.0, PI / 4.0, PI / 2.0).unwrap();
     let tile = ClineArcTile::new(vec![
         LineSegment::new(Complex::Zero, Complex::ONE).into(),
-        CircularArc::new(
-            Circle::unit_circle(),
-            0.0,
-            f64::consts::FRAC_PI_4,
-            f64::consts::FRAC_PI_2,
-        )
-        .into(),
+        CircularArc::new(Circle::unit_circle(), angles).into(),
         LineSegment::new(Complex::I, Complex::Zero).into(),
     ]);
 
@@ -96,9 +90,10 @@ fn main() {
 
     // --
 
+    let more_angles = ArcAngles::new(3.0 * FRAC_PI_2, 7.0 * FRAC_PI_4, TAU).unwrap();
     let another_tile = ClineArcTile::new(vec![
         LineSegment::new(Complex::Zero, -Complex::I).into(),
-        CircularArc::new(Circle::unit_circle(), 3.0 * FRAC_PI_2, 7.0 * FRAC_PI_4, TAU).into(),
+        CircularArc::new(Circle::unit_circle(), more_angles).into(),
         LineSegment::new(Complex::ONE, Complex::Zero).into(),
     ]);
 

--- a/mobius/examples/tricorn.rs
+++ b/mobius/examples/tricorn.rs
@@ -1,4 +1,4 @@
-use std::f64::consts::{FRAC_PI_2, FRAC_PI_4, PI, TAU};
+use std::f64::consts::{FRAC_PI_2, PI, TAU};
 
 use mobius::{
     geometry::{ArcAngles, Circle, CircularArc, LineSegment},
@@ -59,7 +59,7 @@ fn main() {
 
     // ----------------------
 
-    let angles = ArcAngles::new(0.0, PI / 4.0, PI / 2.0).unwrap();
+    let angles = ArcAngles::new(0.0, PI / 2.0).unwrap();
     let tile = ClineArcTile::new(vec![
         LineSegment::new(Complex::Zero, Complex::ONE).into(),
         CircularArc::new(Circle::unit_circle(), angles).into(),
@@ -90,7 +90,7 @@ fn main() {
 
     // --
 
-    let more_angles = ArcAngles::new(3.0 * FRAC_PI_2, 7.0 * FRAC_PI_4, TAU).unwrap();
+    let more_angles = ArcAngles::new(3.0 * FRAC_PI_2, TAU).unwrap();
     let another_tile = ClineArcTile::new(vec![
         LineSegment::new(Complex::Zero, -Complex::I).into(),
         CircularArc::new(Circle::unit_circle(), more_angles).into(),

--- a/mobius/src/algorithms/semigroup_ifs.rs
+++ b/mobius/src/algorithms/semigroup_ifs.rs
@@ -1,8 +1,8 @@
 use std::ops::Index;
 
-use abstraction::{Group, Semigroup};
+use abstraction::Semigroup;
 
-use crate::{transformable::Transformable, Mobius};
+use crate::transformable::Transformable;
 
 /// Iterated Function System. This is still in a prototype stage
 pub struct SemigroupIFS<S: Semigroup> {

--- a/mobius/src/cline_arc.rs
+++ b/mobius/src/cline_arc.rs
@@ -208,6 +208,15 @@ impl From<LineSegment> for ClineArc {
 
 impl Transformable<Isogonal> for ClineArc {
     fn transform(&self, xform: Isogonal) -> Self {
+        let transformed = self.cline.transform(xform);
+        println!(
+            "---\nTransform:\n{}\nby {}\n to {}\n{}",
+            self,
+            xform,
+            transformed,
+            transformed.classify()
+        );
+
         Self {
             cline: self.cline.transform(xform),
             a: xform * self.a,

--- a/mobius/src/cline_arc.rs
+++ b/mobius/src/cline_arc.rs
@@ -1,7 +1,7 @@
 use std::{f64::consts::TAU, fmt::Display};
 
 use crate::{
-    geometry::{Circle, CircularArc, DoubleRay, Line, LineSegment, Ray},
+    geometry::{ArcAngles, Circle, CircularArc, DoubleRay, Line, LineSegment, Ray},
     isogonal::Isogonal,
     rendering::{RenderPrimitive, Renderable},
     transformable::{Cline, GeneralizedCircle, Transformable},
@@ -143,12 +143,11 @@ impl ClineArc {
                 };
 
                 let theta_b = (self.b - center).arg().unwrap();
+                let angles = ArcAngles::new(theta_a, theta_b, end_angle).unwrap();
 
                 ClineArcGeometry::CircularArc(CircularArc {
                     circle: Circle { center, radius },
-                    angle_a: theta_a,
-                    angle_b: theta_b,
-                    angle_c: end_angle,
+                    angles,
                 })
             }
         }
@@ -157,14 +156,9 @@ impl ClineArc {
 
 impl From<CircularArc> for ClineArc {
     fn from(value: CircularArc) -> Self {
-        let CircularArc {
-            circle,
-            angle_a,
-            angle_b,
-            angle_c,
-        } = value;
-
+        let CircularArc { circle, angles } = value;
         let Circle { center, radius } = circle;
+        let ArcAngles(angle_a, angle_b, angle_c) = angles;
         let a = center + Complex::from_polar(radius, angle_a);
         let b = center + Complex::from_polar(radius, angle_b);
         let c = center + Complex::from_polar(radius, angle_c);

--- a/mobius/src/cline_arc.rs
+++ b/mobius/src/cline_arc.rs
@@ -85,7 +85,7 @@ fn compute_ccw_angles(a: f64, b: f64, c: f64) -> Result<ArcAngles, ArcAnglesPars
 
     let adjusted_b = a + delta_b;
     let adjusted_c = adjusted_b + delta_c;
-    ArcAngles::new(a, adjusted_b, adjusted_c)
+    ArcAngles::new(a, adjusted_c)
 }
 
 fn compute_cw_angles(a: f64, b: f64, c: f64) -> Result<ArcAngles, ArcAnglesParseError> {
@@ -95,7 +95,7 @@ fn compute_cw_angles(a: f64, b: f64, c: f64) -> Result<ArcAngles, ArcAnglesParse
 
     let adjusted_b = a - delta_b;
     let adjusted_c = adjusted_b - delta_c;
-    ArcAngles::new(a, adjusted_b, adjusted_c)
+    ArcAngles::new(a, adjusted_c)
 }
 
 impl ClineArc {
@@ -208,7 +208,8 @@ impl From<CircularArc> for ClineArc {
     fn from(value: CircularArc) -> Self {
         let CircularArc { circle, angles } = value;
         let Circle { center, radius } = circle;
-        let ArcAngles(angle_a, angle_b, angle_c) = angles;
+        let ArcAngles(angle_a, angle_c) = angles;
+        let angle_b = 0.5 * (angle_a + angle_c);
         let a = center + Complex::from_polar(radius, angle_a);
         let b = center + Complex::from_polar(radius, angle_b);
         let c = center + Complex::from_polar(radius, angle_c);

--- a/mobius/src/cline_arc.rs
+++ b/mobius/src/cline_arc.rs
@@ -59,15 +59,21 @@ fn compute_ccw_angles(a: f64, b: f64, c: f64) -> ArcAngles {
     let delta_b = (b - a).rem_euclid(TAU);
     let delta_c = (c - b).rem_euclid(TAU);
 
+    let adjusted_b = a + delta_b;
+    let adjusted_c = adjusted_b + delta_c;
+
     // using the full constructor to check for corner cases
-    ArcAngles::new(a, a + delta_b, a + delta_b + delta_c).unwrap()
+    ArcAngles::new(a, adjusted_b, adjusted_c).unwrap()
 }
 
 fn compute_cw_angles(a: f64, b: f64, c: f64) -> ArcAngles {
     // Compute angles in the CW direction
     let delta_b = (a - b).rem_euclid(TAU);
     let delta_c = (b - c).rem_euclid(TAU);
-    ArcAngles::new(a, a - delta_b, a - delta_b - delta_c).unwrap()
+
+    let adjusted_b = a - delta_b;
+    let adjusted_c = adjusted_b - delta_c;
+    ArcAngles::new(a, adjusted_b, adjusted_c).unwrap()
 }
 
 impl ClineArc {

--- a/mobius/src/cline_arc.rs
+++ b/mobius/src/cline_arc.rs
@@ -12,18 +12,20 @@ use crate::{
 
 #[derive(Debug)]
 pub enum ClineArcError {
-    PossiblePrecisionError(ClineArc, Box<dyn Error + 'static>),
+    // To reduce the size of the enum, the first parameter is a pretty-printed
+    // string representation of the cline such that you can see the numeric
+    // values for debugging
+    PossiblePrecisionError(String, Box<dyn Error + 'static>),
 }
 
 impl Display for ClineArcError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::PossiblePrecisionError(arc, inner_error) => {
-                let ClineArc { cline, a, b, c } = arc;
+            Self::PossiblePrecisionError(cline_formatted, inner_error) => {
                 write!(
                     f,
-                    "possible precision issue for ClineArc:\ncline={}\n(a, b, c) = ({}, {}, {})\ncaused by: {}",
-                    cline, a, b, c, inner_error
+                    "possible precision issue for ClineArc:\n{}\ncaused by: {}",
+                    cline_formatted, inner_error
                 )
             }
         }
@@ -189,10 +191,14 @@ impl ClineArc {
                 circle,
                 angles,
             })),
-            Err(err) => Err(ClineArcError::PossiblePrecisionError(
-                self.clone(),
-                Box::new(err),
-            )),
+            Err(err) => {
+                let ClineArc { cline, a, b, c } = self;
+                let message = format!("cline={}\n(a, b, c) = ({}, {}, {})", cline, a, b, c);
+                Err(ClineArcError::PossiblePrecisionError(
+                    message,
+                    Box::new(err),
+                ))
+            }
         }
     }
 

--- a/mobius/src/cline_arc.rs
+++ b/mobius/src/cline_arc.rs
@@ -1,12 +1,36 @@
-use std::{f64::consts::TAU, fmt::Display};
+use std::{error::Error, f64::consts::TAU, fmt::Display};
 
 use crate::{
-    geometry::{ArcAngles, Circle, CircularArc, DoubleRay, Line, LineSegment, Ray},
+    geometry::{
+        ArcAngles, ArcAnglesParseError, Circle, CircularArc, DoubleRay, Line, LineSegment, Ray,
+    },
     isogonal::Isogonal,
     rendering::{RenderPrimitive, Renderable},
     transformable::{Cline, GeneralizedCircle, Transformable},
     Complex,
 };
+
+#[derive(Debug)]
+pub enum ClineArcError {
+    PossiblePrecisionError(ClineArc, Box<dyn Error + 'static>),
+}
+
+impl Display for ClineArcError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::PossiblePrecisionError(arc, inner_error) => {
+                let ClineArc { cline, a, b, c } = arc;
+                write!(
+                    f,
+                    "possible precision issue for ClineArc:\ncline={}\n(a, b, c) = ({}, {}, {})\ncaused by: {}",
+                    cline, a, b, c, inner_error
+                )
+            }
+        }
+    }
+}
+
+impl Error for ClineArcError {}
 
 #[derive(Clone, Copy, Debug)]
 pub enum ClineArcGeometry {
@@ -54,116 +78,128 @@ pub struct ClineArc {
     c: Complex,
 }
 
-fn compute_ccw_angles(a: f64, b: f64, c: f64) -> ArcAngles {
+fn compute_ccw_angles(a: f64, b: f64, c: f64) -> Result<ArcAngles, ArcAnglesParseError> {
     // Compute angles in the CCW direction
     let delta_b = (b - a).rem_euclid(TAU);
     let delta_c = (c - b).rem_euclid(TAU);
 
     let adjusted_b = a + delta_b;
     let adjusted_c = adjusted_b + delta_c;
-
-    // using the full constructor to check for corner cases
-    ArcAngles::new(a, adjusted_b, adjusted_c).unwrap()
+    ArcAngles::new(a, adjusted_b, adjusted_c)
 }
 
-fn compute_cw_angles(a: f64, b: f64, c: f64) -> ArcAngles {
+fn compute_cw_angles(a: f64, b: f64, c: f64) -> Result<ArcAngles, ArcAnglesParseError> {
     // Compute angles in the CW direction
     let delta_b = (a - b).rem_euclid(TAU);
     let delta_c = (b - c).rem_euclid(TAU);
 
     let adjusted_b = a - delta_b;
     let adjusted_c = adjusted_b - delta_c;
-    ArcAngles::new(a, adjusted_b, adjusted_c).unwrap()
+    ArcAngles::new(a, adjusted_b, adjusted_c)
 }
 
 impl ClineArc {
-    pub fn classify(&self) -> ClineArcGeometry {
+    fn compute_line_geometry(&self) -> ClineArcGeometry {
+        if let Complex::Infinity = self.a {
+            // ray goes inf -> b -> c
+            // but it looks like inf <- c
+            let to_infinity = (self.b - self.c).normalize().unwrap();
+            return ClineArcGeometry::FromInfinity(Ray {
+                start: self.c,
+                unit_dir: to_infinity,
+            });
+        }
+
+        if let Complex::Infinity = self.c {
+            // ray goes a -> b -> inf
+            let to_infinity = (self.b - self.a).normalize().unwrap();
+            return ClineArcGeometry::ToInfinity(Ray {
+                start: self.a,
+                unit_dir: to_infinity,
+            });
+        }
+
+        if let Complex::Infinity = self.b {
+            // ray goes    inf <- a    c -> inf
+            let ac = (self.c - self.a).normalize().unwrap();
+            return ClineArcGeometry::ThruInfinity(DoubleRay(
+                Ray {
+                    start: self.a,
+                    unit_dir: -ac,
+                },
+                Ray {
+                    start: self.c,
+                    unit_dir: ac,
+                },
+            ));
+        }
+
+        // All three points are finite so now we we need to check if
+        // if they're in order a -> b -> c. If not, then
+        // the line goes through infinity like
+        //   inf <- a   c <- b <- inf
+        //   inf <- b <- a  c -> inf
+        // in which case we just want a ray pair through a and c.
+        //
+        // we can just check a -> b and b -> c. If the dot product is
+        // positive, then the points are in order.
+        let in_order = Complex::dot(self.b - self.a, self.c - self.b) > 0.0;
+
+        if in_order {
+            ClineArcGeometry::LineSegment(LineSegment {
+                start: self.a,
+                end: self.c,
+            })
+        } else {
+            let ac = (self.c - self.a).normalize().unwrap();
+            ClineArcGeometry::ThruInfinity(DoubleRay(
+                Ray {
+                    start: self.a,
+                    unit_dir: -ac,
+                },
+                Ray {
+                    start: self.c,
+                    unit_dir: ac,
+                },
+            ))
+        }
+    }
+
+    fn compute_circle_geometry(&self, circle: Circle) -> Result<ClineArcGeometry, ClineArcError> {
+        // Determine if the 3 points circulate counterclockwise or
+        // clockwise by forming a triangle ABC and computing
+        // (the magnitude of) the wedge product.
+        let ab = self.b - self.a;
+        let ac = self.c - self.a;
+        let ccw = Complex::wedge(ab, ac) > 0.0;
+
+        // Get the raw angles
+        let theta_a = circle.get_angle(self.a).unwrap();
+        let theta_b = circle.get_angle(self.b).unwrap();
+        let theta_c = circle.get_angle(self.c).unwrap();
+
+        let angles = if ccw {
+            compute_ccw_angles(theta_a, theta_b, theta_c)
+        } else {
+            compute_cw_angles(theta_a, theta_b, theta_c)
+        };
+
+        match angles {
+            Ok(angles) => Ok(ClineArcGeometry::CircularArc(CircularArc {
+                circle,
+                angles,
+            })),
+            Err(err) => Err(ClineArcError::PossiblePrecisionError(
+                self.clone(),
+                Box::new(err),
+            )),
+        }
+    }
+
+    pub fn classify(&self) -> Result<ClineArcGeometry, ClineArcError> {
         match self.cline.classify() {
-            GeneralizedCircle::Line(_) => {
-                if let Complex::Infinity = self.a {
-                    // ray goes inf -> b -> c
-                    // but it looks like inf <- c
-                    let to_infinity = (self.b - self.c).normalize().unwrap();
-                    return ClineArcGeometry::FromInfinity(Ray {
-                        start: self.c,
-                        unit_dir: to_infinity,
-                    });
-                }
-
-                if let Complex::Infinity = self.c {
-                    // ray goes a -> b -> inf
-                    let to_infinity = (self.b - self.a).normalize().unwrap();
-                    return ClineArcGeometry::ToInfinity(Ray {
-                        start: self.a,
-                        unit_dir: to_infinity,
-                    });
-                }
-
-                if let Complex::Infinity = self.b {
-                    // ray goes    inf <- a    c -> inf
-                    let ac = (self.c - self.a).normalize().unwrap();
-                    return ClineArcGeometry::ThruInfinity(DoubleRay(
-                        Ray {
-                            start: self.a,
-                            unit_dir: -ac,
-                        },
-                        Ray {
-                            start: self.c,
-                            unit_dir: ac,
-                        },
-                    ));
-                }
-
-                // All three points are finite so now we we need to check if
-                // if they're in order a -> b -> c. If not, then
-                // the line goes through infinity like
-                //   inf <- a   c <- b <- inf
-                //   inf <- b <- a  c -> inf
-                // in which case we just want a ray pair through a and c.
-                //
-                // we can just check a -> b and b -> c. If the dot product is
-                // positive, then the points are in order.
-                let in_order = Complex::dot(self.b - self.a, self.c - self.b) > 0.0;
-
-                if in_order {
-                    ClineArcGeometry::LineSegment(LineSegment {
-                        start: self.a,
-                        end: self.c,
-                    })
-                } else {
-                    let ac = (self.c - self.a).normalize().unwrap();
-                    ClineArcGeometry::ThruInfinity(DoubleRay(
-                        Ray {
-                            start: self.a,
-                            unit_dir: -ac,
-                        },
-                        Ray {
-                            start: self.c,
-                            unit_dir: ac,
-                        },
-                    ))
-                }
-            }
-            GeneralizedCircle::Circle(circle) => {
-                // Determine if the 3 points circulate counterclockwise or
-                // clockwise by forming a triangle ABC and computing
-                // (the magnitude of) the wedge product.
-                let ab = self.b - self.a;
-                let ac = self.c - self.a;
-                let ccw = Complex::wedge(ab, ac) > 0.0;
-
-                // Get the raw angles
-                let theta_a = circle.get_angle(self.a).unwrap();
-                let theta_b = circle.get_angle(self.b).unwrap();
-                let theta_c = circle.get_angle(self.c).unwrap();
-
-                let angles = if ccw {
-                    compute_ccw_angles(theta_a, theta_b, theta_c)
-                } else {
-                    compute_cw_angles(theta_a, theta_b, theta_c)
-                };
-                ClineArcGeometry::CircularArc(CircularArc { circle, angles })
-            }
+            GeneralizedCircle::Line(_) => Ok(self.compute_line_geometry()),
+            GeneralizedCircle::Circle(circle) => self.compute_circle_geometry(circle),
         }
     }
 }
@@ -208,14 +244,16 @@ impl From<LineSegment> for ClineArc {
 
 impl Transformable<Isogonal> for ClineArc {
     fn transform(&self, xform: Isogonal) -> Self {
-        let transformed = self.cline.transform(xform);
-        println!(
-            "---\nTransform:\n{}\nby {}\n to {}\n{}",
-            self,
-            xform,
-            transformed,
-            transformed.classify()
-        );
+        if cfg!(feature = "debug_cline_arcs") {
+            let transformed = self.cline.transform(xform);
+            println!(
+                "---\nTransform:\n{}\nby {}\n to {}\n{}",
+                self,
+                xform,
+                transformed,
+                transformed.classify()
+            );
+        }
 
         Self {
             cline: self.cline.transform(xform),
@@ -227,10 +265,11 @@ impl Transformable<Isogonal> for ClineArc {
 }
 
 impl Renderable for ClineArc {
-    fn bake_geometry(&self) -> Vec<RenderPrimitive> {
+    fn bake_geometry(&self) -> Result<Vec<RenderPrimitive>, Box<dyn std::error::Error>> {
         let mut result = Vec::new();
 
-        let (first, maybe_second) = match self.classify() {
+        let geom = self.classify()?;
+        let (first, maybe_second) = match geom {
             ClineArcGeometry::CircularArc(arc) => (RenderPrimitive::CircularArc(arc), None),
             ClineArcGeometry::LineSegment(line_segment) => {
                 (RenderPrimitive::LineSegment(line_segment), None)
@@ -249,12 +288,13 @@ impl Renderable for ClineArc {
             result.push(x);
         }
 
-        result
+        Ok(result)
     }
 }
 
 impl Display for ClineArc {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        self.classify().fmt(f)
+        let geom = self.classify().unwrap();
+        geom.fmt(f)
     }
 }

--- a/mobius/src/complex.rs
+++ b/mobius/src/complex.rs
@@ -255,6 +255,11 @@ mod test {
     use super::*;
     use test_case::test_case;
 
+    #[test]
+    pub fn missing_tests() {
+        todo!("wedge tests");
+    }
+
     #[should_panic]
     #[test_case(-3.0, f64::NAN; "NaN in imaginary part")]
     #[test_case(f64::NAN, 3.0; "NaN in real part")]

--- a/mobius/src/float_error.rs
+++ b/mobius/src/float_error.rs
@@ -1,0 +1,27 @@
+use std::{error::Error, fmt::Display};
+
+#[derive(Debug)]
+pub enum FloatError {
+    NonFinite(String, f64),
+}
+
+impl FloatError {
+    /// Require a float value to be a finite value, not 0 or infinity
+    pub fn require_finite(label: &str, x: f64) -> Result<(), Self> {
+        if !x.is_finite() {
+            Err(Self::NonFinite(String::from(label), x))
+        } else {
+            Ok(())
+        }
+    }
+}
+
+impl Display for FloatError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NonFinite(var, val) => write!(f, "value must be finite: {} = {}", var, val),
+        }
+    }
+}
+
+impl Error for FloatError {}

--- a/mobius/src/geometry/arc_angles.rs
+++ b/mobius/src/geometry/arc_angles.rs
@@ -20,8 +20,9 @@ impl ArcAngles {
         let is_strictly_decreasing = a > b && b > c;
 
         if !is_strictly_increasing && !is_strictly_decreasing {
-            return Err(String::from(
-                "angles must be strictly increasing or strictly decreasing",
+            return Err(format!(
+                "angles must be strictly increasing or strictly decreasing: ({}, {}, {})",
+                a, b, c
             ));
         }
 

--- a/mobius/src/geometry/arc_angles.rs
+++ b/mobius/src/geometry/arc_angles.rs
@@ -1,9 +1,54 @@
 use std::{
+    error::Error,
     f64::consts::{PI, TAU},
     fmt::Display,
 };
 
-use crate::nearly::is_nearly;
+use crate::{float_error::FloatError, nearly::is_nearly};
+
+#[derive(Debug)]
+pub enum ArcAnglesParseError {
+    /// One of the input floats is not valid
+    BadFloat(FloatError),
+    /// Arc angles must be specified in either strictly increasing
+    /// or strictly decreasing order
+    NotStrictlyMonotone(f64, f64, f64),
+    /// Arc is bigger than a full circle, I'm not supporting this.
+    BigArcNotSupported(f64, f64, f64),
+}
+
+impl Display for ArcAnglesParseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::BadFloat(err) => err.fmt(f),
+            Self::NotStrictlyMonotone(a, b, c) => write!(
+                f,
+                "angles must be either strictly increasing or strictly decreasing: ({}, {}, {})",
+                a, b, c
+            ),
+            Self::BigArcNotSupported(a, b, c) => write!(
+                f,
+                "only arcs smaller than a full circle are supported: ({}, {}, {})",
+                a, b, c
+            ),
+        }
+    }
+}
+
+impl From<FloatError> for ArcAnglesParseError {
+    fn from(value: FloatError) -> Self {
+        Self::BadFloat(value)
+    }
+}
+
+impl Error for ArcAnglesParseError {}
+
+#[derive(Clone, Copy, PartialEq, Debug)]
+pub enum ArcDirection {
+    // Counter-clockwise
+    Counterclockwise,
+    Clockwise,
+}
 
 /// Angles for use with CircularArc. These are subject to the following
 /// restrictions:
@@ -14,25 +59,34 @@ use crate::nearly::is_nearly;
 #[derive(Clone, Copy, Debug)]
 pub struct ArcAngles(pub f64, pub f64, pub f64);
 
+/// Reduce angles so a is in [0, 2pi)
+fn reduce_angles(a: f64, b: f64, c: f64) -> (f64, f64, f64) {
+    let reduced_a = a.rem_euclid(TAU);
+    let reduced_b = (b - a) + reduced_a;
+    let reduced_c = (c - a) + reduced_a;
+
+    (reduced_a, reduced_b, reduced_c)
+}
+
 impl ArcAngles {
-    pub fn new(a: f64, b: f64, c: f64) -> Result<Self, String> {
+    pub fn new(a: f64, b: f64, c: f64) -> Result<Self, ArcAnglesParseError> {
+        FloatError::require_finite("a", a)?;
+        FloatError::require_finite("b", b)?;
+        FloatError::require_finite("c", c)?;
+
         let is_strictly_increasing = a < b && b < c;
         let is_strictly_decreasing = a > b && b > c;
 
         if !is_strictly_increasing && !is_strictly_decreasing {
-            return Err(format!(
-                "angles must be strictly increasing or strictly decreasing: ({}, {}, {})",
-                a, b, c
-            ));
+            return Err(ArcAnglesParseError::NotStrictlyMonotone(a, b, c));
         }
 
         if (c - a).abs() >= TAU {
-            return Err(String::from(
-                "only arcs less than a full circle are supported",
-            ));
+            return Err(ArcAnglesParseError::BigArcNotSupported(a, b, c));
         }
 
-        Ok(Self(a, b, c))
+        let (reduced_a, reduced_b, reduced_c) = reduce_angles(a, b, c);
+        Ok(Self(reduced_a, reduced_b, reduced_c))
     }
 
     /// Create two semicircles, one for the upper half of a circle traced
@@ -43,24 +97,32 @@ impl ArcAngles {
         (upper, lower)
     }
 
+    pub fn direction(&self) -> ArcDirection {
+        let Self(a, _, c) = self;
+        if c > a {
+            ArcDirection::Counterclockwise
+        } else {
+            ArcDirection::Clockwise
+        }
+    }
+
     /// Return the same arc but traced backwards.
     pub fn reverse(&self) -> Self {
         let Self(a, b, c) = self;
 
-        Self(*c, *b, *a)
+        let (reduced_a, reduced_b, reduced_c) = reduce_angles(*c, *b, *a);
+        Self(reduced_a, reduced_b, reduced_c)
     }
 }
 
 impl PartialEq for ArcAngles {
     fn eq(&self, other: &Self) -> bool {
-        let ArcAngles(a, b, c) = self;
-        let ArcAngles(e, f, g) = other;
+        let ArcAngles(a, _, c) = self;
+        let ArcAngles(e, _, g) = other;
 
-        let same_start_point = is_nearly(a % TAU, b % TAU);
-        let same_ab = is_nearly(b - a, f - e);
-        let same_bc = is_nearly(c - b, g - f);
+        // Even if the midpoints were to differ, the strictly
 
-        same_start_point && same_ab && same_bc
+        is_nearly(*a, *e) && is_nearly(*c, *g)
     }
 }
 
@@ -79,7 +141,9 @@ impl Display for ArcAngles {
 
 #[cfg(test)]
 mod test {
-    use std::f64::{consts::PI, NAN};
+    use std::f64::{consts::PI, INFINITY, NAN};
+
+    use crate::nearly::assert_nearly;
 
     use super::*;
     use test_case::test_case;
@@ -87,9 +151,15 @@ mod test {
     #[test_case(NAN, 1.0, 0.0; "nan a")]
     #[test_case(0.0,  NAN, 3.0; "nan b")]
     #[test_case(0.0, 1.0, NAN; "nan c")]
-    #[should_panic]
-    pub fn new_with_nan_panics(a: f64, b: f64, c: f64) {
-        let _ = ArcAngles::new(a, b, c);
+    #[test_case(INFINITY, 1.0, 0.0; "inf a")]
+    #[test_case(1.0, INFINITY, 0.0; "inf b")]
+    #[test_case(1.0, 0.0, INFINITY; "inf c")]
+    pub fn new_with_non_finite_returns_error(a: f64, b: f64, c: f64) {
+        let result = ArcAngles::new(a, b, c);
+        assert!(result.is_err_and(|x| matches!(
+            x,
+            ArcAnglesParseError::BadFloat(FloatError::NonFinite(_, _))
+        )));
     }
 
     #[test_case(0.0, 1.0, 0.5; "neither increasing or decreasing")]
@@ -99,9 +169,8 @@ mod test {
     #[test_case(0.0, 0.0, 0.0; "degenerate arc")]
     pub fn new_with_non_monotone_angles_returns_error(a: f64, b: f64, c: f64) {
         let result = ArcAngles::new(a, b, c);
-
         assert!(
-            result.is_err_and(|x| x.contains("must be strictly increasing or strictly decreasing"))
+            result.is_err_and(|x| matches!(x, ArcAnglesParseError::NotStrictlyMonotone(_, _, _)))
         );
     }
 
@@ -110,36 +179,87 @@ mod test {
     #[test_case(0.0, -TAU, -2.0 * TAU; "big clockwise arc")]
     pub fn new_with_big_angle_returns_error(a: f64, b: f64, c: f64) {
         let result = ArcAngles::new(a, b, c);
-
-        assert!(result.is_err_and(|x| x.contains("less than a full circle")));
+        assert!(
+            result.is_err_and(|x| matches!(x, ArcAnglesParseError::BigArcNotSupported(_, _, _)))
+        );
     }
 
     #[test_case(0.0, PI / 2.0, PI; "ccw arc")]
-    #[test_case(-PI / 2.0, 0.0, PI; "ccw arc that straddles 0")]
-    #[test_case(PI / 2.0, PI, 3.0 * PI / 2.0)]
+    #[test_case(PI, 3.0 * PI/4.0, PI/2.0; "cw arc")]
+    #[test_case(PI / 2.0, PI, 3.0 * PI / 2.0; "ccw arc that straddles pi")]
     pub fn new_with_valid_angles_constructs(a: f64, b: f64, c: f64) {
         let result = ArcAngles::new(a, b, c);
 
         assert!(result.is_ok_and(|ArcAngles(x, y, z)| x == a && y == b && z == c));
     }
 
-    #[test]
-    pub fn equals() {
-        todo!("partial equality tests");
+    #[test_case(2.0 * PI, 5.0 * PI/ 2.0, 3.0 * PI, 0.0, PI / 2.0, PI; "a exactly at 2pi")]
+    #[test_case(9.0 * PI/4.0, 5.0 * PI / 2.0, 11.0 * PI /4.0, PI / 4.0, PI / 2.0, 3.0 * PI/4.0; "bigger than 2pi")]
+    #[test_case(-PI/4.0, -PI/2.0, -3.0 * PI/4.0, 7.0 * PI / 4.0, 3.0 * PI / 2.0, 5.0 * PI / 4.0; "a negative")]
+    pub fn new_with_out_of_range_a_constructs_reduced(
+        a: f64,
+        b: f64,
+        c: f64,
+        expected_x: f64,
+        expected_y: f64,
+        expected_z: f64,
+    ) {
+        let result = ArcAngles::new(a, b, c);
+
+        assert!(result.is_ok());
+        let ArcAngles(x, y, z) = result.unwrap();
+        assert_nearly(x, expected_x);
+        assert_nearly(y, expected_y);
+        assert_nearly(z, expected_z);
+    }
+
+    #[test_case(ArcAngles::new(0.0, PI / 3.0, PI / 2.0).unwrap(); "ccw arc")]
+    #[test_case(ArcAngles::new(0.0, -PI / 3.0, -PI / 2.0).unwrap(); "cw arc")]
+    pub fn arc_equals_itself(a: ArcAngles) {
+        assert_eq!(a, a);
     }
 
     #[test]
-    pub fn display() {
-        todo!("display tests");
+    pub fn arcs_with_different_midpoint_are_equal() {
+        let arc = ArcAngles::new(0.0, PI / 2.0, PI).unwrap();
+        let different_midpoint = ArcAngles::new(0.0, PI / 3.0, PI).unwrap();
+
+        assert_eq!(arc, different_midpoint);
+    }
+
+    #[test_case(ArcAngles::new(0.0, PI / 2.0, PI).unwrap(), ArcDirection::Counterclockwise; "ccw arc")]
+    #[test_case(ArcAngles::new(0.0, - PI / 4.0, - PI / 2.0).unwrap(), ArcDirection::Clockwise; "cw arc")]
+    pub fn arc_computes_correct_direction(a: ArcAngles, expected_dir: ArcDirection) {
+        let direction = a.direction();
+
+        assert_eq!(direction, expected_dir);
     }
 
     #[test]
-    pub fn semicircles() {
-        todo!("semicircle tests");
+    pub fn semicircles_computes_upper_and_lower_arcs() {
+        let (upper, lower) = ArcAngles::semicircles();
+
+        let expected_upper = ArcAngles::new(0.0, PI / 2.0, PI).unwrap();
+        let expected_lower = ArcAngles::new(PI, 3.0 * PI / 2.0, 2.0 * PI).unwrap();
+        assert_eq!(upper, expected_upper);
+        assert_eq!(lower, expected_lower);
     }
 
     #[test]
-    pub fn reverse() {
-        todo!("reverse tests")
+    pub fn reverse_with_in_range_c_reverses_angles() {
+        let arc = ArcAngles::new(PI / 6.0, PI / 4.0, PI / 3.0).unwrap();
+
+        let result = arc.reverse();
+
+        let expected = ArcAngles::new(PI / 3.0, PI / 4.0, PI / 6.0).unwrap();
+        assert_eq!(result, expected);
+    }
+
+    #[test_case(ArcAngles::new(0.0, -PI / 2.0, -PI).unwrap(), ArcAngles::new(PI, 3.0 * PI / 2.0, 2.0 * PI).unwrap(); "cw arc")]
+    #[test_case(ArcAngles::new(7.0 * PI / 4.0, 2.0 * PI, 5.0 * PI / 2.0).unwrap(), ArcAngles::new(PI / 2.0, 0.0, -PI / 4.0).unwrap(); "ccw arc through 2pi")]
+    pub fn reverse_with_out_of_range_c_reduces_angles(arc: ArcAngles, expected: ArcAngles) {
+        let result = arc.reverse();
+
+        assert_eq!(result, expected);
     }
 }

--- a/mobius/src/geometry/arc_angles.rs
+++ b/mobius/src/geometry/arc_angles.rs
@@ -10,26 +10,21 @@ use crate::{float_error::FloatError, nearly::is_nearly};
 pub enum ArcAnglesParseError {
     /// One of the input floats is not valid
     BadFloat(FloatError),
-    /// Arc angles must be specified in either strictly increasing
-    /// or strictly decreasing order
-    NotStrictlyMonotone(f64, f64, f64),
-    /// Arc is bigger than a full circle, I'm not supporting this.
-    BigArcNotSupported(f64, f64, f64),
+    /// Arc angles must be distinct
+    DegenerateArc(f64),
+    /// Arc is bigger than a full circle. I'm not supporting this case
+    BigArcNotSupported(f64, f64),
 }
 
 impl Display for ArcAnglesParseError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::BadFloat(err) => err.fmt(f),
-            Self::NotStrictlyMonotone(a, b, c) => write!(
+            Self::DegenerateArc(a) => write!(f, "arc angles must be distinct: ({}, {})", a, a),
+            Self::BigArcNotSupported(a, b) => write!(
                 f,
-                "angles must be either strictly increasing or strictly decreasing: ({}, {}, {})",
-                a, b, c
-            ),
-            Self::BigArcNotSupported(a, b, c) => write!(
-                f,
-                "only arcs smaller than a full circle are supported: ({}, {}, {})",
-                a, b, c
+                "only arcs smaller than a full circle are supported: ({}, {})",
+                a, b
             ),
         }
     }
@@ -50,6 +45,15 @@ pub enum ArcDirection {
     Clockwise,
 }
 
+impl Display for ArcDirection {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Clockwise => write!(f, "CW"),
+            Self::Counterclockwise => write!(f, "CCW"),
+        }
+    }
+}
+
 /// Angles for use with CircularArc. These are subject to the following
 /// restrictions:
 ///
@@ -57,49 +61,44 @@ pub enum ArcDirection {
 /// - |c - a| < 2pi so we're always drawing less than a full circle
 /// - the value of a will be reduced to be in [0, 2pi)
 #[derive(Clone, Copy, Debug)]
-pub struct ArcAngles(pub f64, pub f64, pub f64);
+pub struct ArcAngles(pub f64, pub f64);
 
 /// Reduce angles so a is in [0, 2pi)
-fn reduce_angles(a: f64, b: f64, c: f64) -> (f64, f64, f64) {
+fn reduce_angles(a: f64, b: f64) -> (f64, f64) {
     let reduced_a = a.rem_euclid(TAU);
     let reduced_b = (b - a) + reduced_a;
-    let reduced_c = (c - a) + reduced_a;
 
-    (reduced_a, reduced_b, reduced_c)
+    (reduced_a, reduced_b)
 }
 
 impl ArcAngles {
-    pub fn new(a: f64, b: f64, c: f64) -> Result<Self, ArcAnglesParseError> {
+    pub fn new(a: f64, b: f64) -> Result<Self, ArcAnglesParseError> {
         FloatError::require_finite("a", a)?;
         FloatError::require_finite("b", b)?;
-        FloatError::require_finite("c", c)?;
 
-        let is_strictly_increasing = a < b && b < c;
-        let is_strictly_decreasing = a > b && b > c;
-
-        if !is_strictly_increasing && !is_strictly_decreasing {
-            return Err(ArcAnglesParseError::NotStrictlyMonotone(a, b, c));
+        if a == b {
+            return Err(ArcAnglesParseError::DegenerateArc(a));
         }
 
-        if (c - a).abs() >= TAU {
-            return Err(ArcAnglesParseError::BigArcNotSupported(a, b, c));
+        if (b - a).abs() >= TAU {
+            return Err(ArcAnglesParseError::BigArcNotSupported(a, b));
         }
 
-        let (reduced_a, reduced_b, reduced_c) = reduce_angles(a, b, c);
-        Ok(Self(reduced_a, reduced_b, reduced_c))
+        let (reduced_a, reduced_b) = reduce_angles(a, b);
+        Ok(Self(reduced_a, reduced_b))
     }
 
     /// Create two semicircles, one for the upper half of a circle traced
     /// from 0 to pi, the other is the lower half from pi to 2pi
     pub fn semicircles() -> (Self, Self) {
-        let upper = Self(0.0, PI / 2.0, PI);
-        let lower = Self(PI, 3.0 * PI / 2.0, TAU);
+        let upper = Self(0.0, PI);
+        let lower = Self(PI, TAU);
         (upper, lower)
     }
 
     pub fn direction(&self) -> ArcDirection {
-        let Self(a, _, c) = self;
-        if c > a {
+        let Self(a, b) = self;
+        if b > a {
             ArcDirection::Counterclockwise
         } else {
             ArcDirection::Clockwise
@@ -108,33 +107,33 @@ impl ArcAngles {
 
     /// Return the same arc but traced backwards.
     pub fn reverse(&self) -> Self {
-        let Self(a, b, c) = self;
+        let Self(a, b) = self;
 
-        let (reduced_a, reduced_b, reduced_c) = reduce_angles(*c, *b, *a);
-        Self(reduced_a, reduced_b, reduced_c)
+        let (reduced_a, reduced_b) = reduce_angles(*b, *a);
+        Self(reduced_a, reduced_b)
     }
 }
 
 impl PartialEq for ArcAngles {
     fn eq(&self, other: &Self) -> bool {
-        let ArcAngles(a, _, c) = self;
-        let ArcAngles(e, _, g) = other;
+        let ArcAngles(a, b) = self;
+        let ArcAngles(c, d) = other;
 
         // Even if the midpoints were to differ, the strictly
 
-        is_nearly(*a, *e) && is_nearly(*c, *g)
+        is_nearly(*a, *c) && is_nearly(*b, *d)
     }
 }
 
 impl Display for ArcAngles {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let Self(a, b, c) = self;
+        let Self(a, b) = self;
         write!(
             f,
-            "{:.3}° -> {:.3}° -> {:.3}°",
+            "{:.3}° -> {:.3}° ({})",
             a.to_degrees(),
             b.to_degrees(),
-            c.to_degrees()
+            self.direction()
         )
     }
 }
@@ -148,87 +147,77 @@ mod test {
     use super::*;
     use test_case::test_case;
 
-    #[test_case(NAN, 1.0, 0.0; "nan a")]
-    #[test_case(0.0,  NAN, 3.0; "nan b")]
-    #[test_case(0.0, 1.0, NAN; "nan c")]
-    #[test_case(INFINITY, 1.0, 0.0; "inf a")]
-    #[test_case(1.0, INFINITY, 0.0; "inf b")]
-    #[test_case(1.0, 0.0, INFINITY; "inf c")]
-    pub fn new_with_non_finite_returns_error(a: f64, b: f64, c: f64) {
-        let result = ArcAngles::new(a, b, c);
+    #[test_case(NAN, 1.0; "nan a")]
+    #[test_case(0.0,  NAN; "nan b")]
+    #[test_case(INFINITY, 1.0; "inf a")]
+    #[test_case(1.0, INFINITY; "inf b")]
+    pub fn new_with_non_finite_returns_error(a: f64, b: f64) {
+        let result = ArcAngles::new(a, b);
         assert!(result.is_err_and(|x| matches!(
             x,
             ArcAnglesParseError::BadFloat(FloatError::NonFinite(_, _))
         )));
     }
 
-    #[test_case(0.0, 1.0, 0.5; "neither increasing or decreasing")]
-    #[test_case(0.0, 0.0, 1.0; "not strictly increasing")]
-    #[test_case(1.0, 0.0, 0.0; "not strictly decreasing")]
-    #[test_case(PI, -PI, -PI / 2.0; "angles not specified in correct form")]
-    #[test_case(0.0, 0.0, 0.0; "degenerate arc")]
-    pub fn new_with_non_monotone_angles_returns_error(a: f64, b: f64, c: f64) {
-        let result = ArcAngles::new(a, b, c);
-        assert!(
-            result.is_err_and(|x| matches!(x, ArcAnglesParseError::NotStrictlyMonotone(_, _, _)))
-        );
+    #[test]
+    pub fn new_with_repeated_angles_returns_error() {
+        let angle = PI / 4.0;
+
+        let result = ArcAngles::new(angle, angle);
+
+        assert!(result.is_err_and(|x| matches!(x, ArcAnglesParseError::DegenerateArc(_))));
     }
 
-    #[test_case(0.0, PI, TAU; "full circle")]
-    #[test_case(0.0, TAU, 1.5 * TAU; "bigger than full_circle")]
-    #[test_case(0.0, -TAU, -2.0 * TAU; "big clockwise arc")]
-    pub fn new_with_big_angle_returns_error(a: f64, b: f64, c: f64) {
-        let result = ArcAngles::new(a, b, c);
-        assert!(
-            result.is_err_and(|x| matches!(x, ArcAnglesParseError::BigArcNotSupported(_, _, _)))
-        );
+    #[test_case(0.0, TAU; "full circle")]
+    #[test_case(0.0, 1.5 * TAU; "bigger than full_circle")]
+    #[test_case(0.0, -2.0 * TAU; "big clockwise arc")]
+    pub fn new_with_big_angle_returns_error(a: f64, b: f64) {
+        let result = ArcAngles::new(a, b);
+        assert!(result.is_err_and(|x| matches!(x, ArcAnglesParseError::BigArcNotSupported(_, _))));
     }
 
-    #[test_case(0.0, PI / 2.0, PI; "ccw arc")]
-    #[test_case(PI, 3.0 * PI/4.0, PI/2.0; "cw arc")]
-    #[test_case(PI / 2.0, PI, 3.0 * PI / 2.0; "ccw arc that straddles pi")]
-    pub fn new_with_valid_angles_constructs(a: f64, b: f64, c: f64) {
-        let result = ArcAngles::new(a, b, c);
+    #[test_case(0.0, PI; "ccw arc")]
+    #[test_case(PI, PI / 2.0; "cw arc")]
+    #[test_case(PI / 2.0, 3.0 * PI / 2.0; "ccw arc that straddles pi")]
+    pub fn new_with_valid_angles_constructs(a: f64, b: f64) {
+        let result = ArcAngles::new(a, b);
 
-        assert!(result.is_ok_and(|ArcAngles(x, y, z)| x == a && y == b && z == c));
+        assert!(result.is_ok_and(|ArcAngles(x, y)| x == a && y == b));
     }
 
-    #[test_case(2.0 * PI, 5.0 * PI/ 2.0, 3.0 * PI, 0.0, PI / 2.0, PI; "a exactly at 2pi")]
-    #[test_case(9.0 * PI/4.0, 5.0 * PI / 2.0, 11.0 * PI /4.0, PI / 4.0, PI / 2.0, 3.0 * PI/4.0; "bigger than 2pi")]
-    #[test_case(-PI/4.0, -PI/2.0, -3.0 * PI/4.0, 7.0 * PI / 4.0, 3.0 * PI / 2.0, 5.0 * PI / 4.0; "a negative")]
+    #[test_case(2.0 * PI, 3.0 * PI, 0.0, PI; "a exactly at 2pi")]
+    #[test_case(9.0 * PI/4.0,  11.0 * PI /4.0, PI / 4.0, 3.0 * PI/4.0; "bigger than 2pi")]
+    #[test_case(-PI/4.0, -3.0 * PI/4.0, 7.0 * PI / 4.0, 5.0 * PI / 4.0; "a negative")]
     pub fn new_with_out_of_range_a_constructs_reduced(
         a: f64,
         b: f64,
-        c: f64,
         expected_x: f64,
         expected_y: f64,
-        expected_z: f64,
     ) {
-        let result = ArcAngles::new(a, b, c);
+        let result = ArcAngles::new(a, b);
 
         assert!(result.is_ok());
-        let ArcAngles(x, y, z) = result.unwrap();
+        let ArcAngles(x, y) = result.unwrap();
         assert_nearly(x, expected_x);
         assert_nearly(y, expected_y);
-        assert_nearly(z, expected_z);
     }
 
-    #[test_case(ArcAngles::new(0.0, PI / 3.0, PI / 2.0).unwrap(); "ccw arc")]
-    #[test_case(ArcAngles::new(0.0, -PI / 3.0, -PI / 2.0).unwrap(); "cw arc")]
+    #[test_case(ArcAngles::new(0.0, PI / 2.0).unwrap(); "ccw arc")]
+    #[test_case(ArcAngles::new(0.0, -PI / 2.0).unwrap(); "cw arc")]
     pub fn arc_equals_itself(a: ArcAngles) {
         assert_eq!(a, a);
     }
 
     #[test]
     pub fn arcs_with_different_midpoint_are_equal() {
-        let arc = ArcAngles::new(0.0, PI / 2.0, PI).unwrap();
-        let different_midpoint = ArcAngles::new(0.0, PI / 3.0, PI).unwrap();
+        let arc = ArcAngles::new(0.0, PI).unwrap();
+        let different_midpoint = ArcAngles::new(0.0, PI).unwrap();
 
         assert_eq!(arc, different_midpoint);
     }
 
-    #[test_case(ArcAngles::new(0.0, PI / 2.0, PI).unwrap(), ArcDirection::Counterclockwise; "ccw arc")]
-    #[test_case(ArcAngles::new(0.0, - PI / 4.0, - PI / 2.0).unwrap(), ArcDirection::Clockwise; "cw arc")]
+    #[test_case(ArcAngles::new(0.0, PI).unwrap(), ArcDirection::Counterclockwise; "ccw arc")]
+    #[test_case(ArcAngles::new(0.0, - PI / 2.0).unwrap(), ArcDirection::Clockwise; "cw arc")]
     pub fn arc_computes_correct_direction(a: ArcAngles, expected_dir: ArcDirection) {
         let direction = a.direction();
 
@@ -239,24 +228,24 @@ mod test {
     pub fn semicircles_computes_upper_and_lower_arcs() {
         let (upper, lower) = ArcAngles::semicircles();
 
-        let expected_upper = ArcAngles::new(0.0, PI / 2.0, PI).unwrap();
-        let expected_lower = ArcAngles::new(PI, 3.0 * PI / 2.0, 2.0 * PI).unwrap();
+        let expected_upper = ArcAngles::new(0.0, PI).unwrap();
+        let expected_lower = ArcAngles::new(PI, 2.0 * PI).unwrap();
         assert_eq!(upper, expected_upper);
         assert_eq!(lower, expected_lower);
     }
 
     #[test]
     pub fn reverse_with_in_range_c_reverses_angles() {
-        let arc = ArcAngles::new(PI / 6.0, PI / 4.0, PI / 3.0).unwrap();
+        let arc = ArcAngles::new(PI / 6.0, PI / 3.0).unwrap();
 
         let result = arc.reverse();
 
-        let expected = ArcAngles::new(PI / 3.0, PI / 4.0, PI / 6.0).unwrap();
+        let expected = ArcAngles::new(PI / 3.0, PI / 6.0).unwrap();
         assert_eq!(result, expected);
     }
 
-    #[test_case(ArcAngles::new(0.0, -PI / 2.0, -PI).unwrap(), ArcAngles::new(PI, 3.0 * PI / 2.0, 2.0 * PI).unwrap(); "cw arc")]
-    #[test_case(ArcAngles::new(7.0 * PI / 4.0, 2.0 * PI, 5.0 * PI / 2.0).unwrap(), ArcAngles::new(PI / 2.0, 0.0, -PI / 4.0).unwrap(); "ccw arc through 2pi")]
+    #[test_case(ArcAngles::new(0.0,  -PI).unwrap(), ArcAngles::new(PI, 2.0 * PI).unwrap(); "cw arc")]
+    #[test_case(ArcAngles::new(7.0 * PI / 4.0,  5.0 * PI / 2.0).unwrap(), ArcAngles::new(PI / 2.0,  -PI / 4.0).unwrap(); "ccw arc through 2pi")]
     pub fn reverse_with_out_of_range_c_reduces_angles(arc: ArcAngles, expected: ArcAngles) {
         let result = arc.reverse();
 

--- a/mobius/src/geometry/arc_angles.rs
+++ b/mobius/src/geometry/arc_angles.rs
@@ -1,0 +1,68 @@
+use std::f64::consts::TAU;
+
+/// Angles for use with CircularArc. These are subject to the following
+/// restrictions:
+///
+/// - a < b < c (CCW arc) or a > b > c (CW arc). This reduces corner cases
+/// - |c - a| < 2pi so we're always drawing less than a full circle
+pub struct ArcAngles(pub f64, pub f64, pub f64);
+
+impl ArcAngles {
+    pub fn new(a: f64, b: f64, c: f64) -> Result<Self, String> {
+        let is_strictly_increasing = a < b && b < c;
+        let is_strictly_decreasing = a > b && b > c;
+
+        if !is_strictly_increasing && !is_strictly_decreasing {
+            return Err(String::from(
+                "angles must be strictly increasing or strictly decreasing",
+            ));
+        }
+
+        if (c - a).abs() >= TAU {
+            return Err(String::from(
+                "only arcs less than a full circle are supported",
+            ));
+        }
+
+        Ok(Self(a, b, c))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::f64::consts::PI;
+
+    use super::*;
+    use test_case::test_case;
+
+    #[test_case(0.0, 1.0, 0.5; "neither increasing or decreasing")]
+    #[test_case(0.0, 0.0, 1.0; "not strictly increasing")]
+    #[test_case(1.0, 0.0, 0.0; "not strictly decreasing")]
+    #[test_case(PI, -PI, -PI / 2.0; "angles not specified in correct form")]
+    #[test_case(0.0, 0.0, 0.0; "degenerate arc")]
+    pub fn new_with_non_monotone_angles_returns_error(a: f64, b: f64, c: f64) {
+        let result = ArcAngles::new(a, b, c);
+
+        assert!(
+            result.is_err_and(|x| x.contains("must be strictly increasing or strictly decreasing"))
+        );
+    }
+
+    #[test_case(0.0, PI, TAU; "full circle")]
+    #[test_case(0.0, TAU, 1.5 * TAU; "bigger than full_circle")]
+    #[test_case(0.0, -TAU, -2.0 * TAU; "big clockwise arc")]
+    pub fn new_with_big_angle_returns_error(a: f64, b: f64, c: f64) {
+        let result = ArcAngles::new(a, b, c);
+
+        assert!(result.is_err_and(|x| x.contains("less than a full circle")));
+    }
+
+    #[test_case(0.0, PI / 2.0, PI; "ccw arc")]
+    #[test_case(-PI / 2.0, 0.0, PI; "ccw arc that straddles 0")]
+    #[test_case(PI / 2.0, PI, 3.0 * PI / 2.0)]
+    pub fn new_with_valid_angles_constructs(a: f64, b: f64, c: f64) {
+        let result = ArcAngles::new(a, b, c);
+
+        assert!(result.is_ok_and(|ArcAngles(x, y, z)| x == a && y == b && z == c));
+    }
+}

--- a/mobius/src/geometry/arc_angles.rs
+++ b/mobius/src/geometry/arc_angles.rs
@@ -67,7 +67,13 @@ impl PartialEq for ArcAngles {
 impl Display for ArcAngles {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let Self(a, b, c) = self;
-        write!(f, "{:.3}° -> {:.3}° -> {:.3}°", a, b, c)
+        write!(
+            f,
+            "{:.3}° -> {:.3}° -> {:.3}°",
+            a.to_degrees(),
+            b.to_degrees(),
+            c.to_degrees()
+        )
     }
 }
 

--- a/mobius/src/geometry/circular_arc.rs
+++ b/mobius/src/geometry/circular_arc.rs
@@ -2,36 +2,31 @@ use std::fmt::Display;
 
 use crate::Complex;
 
-use super::{circle::Circle, DirectedEdge, Geometry};
+use super::{circle::Circle, ArcAngles, DirectedEdge, Geometry};
 
 // Directed circular arc through 3 points on a circular arc
 #[derive(PartialEq, Clone, Copy, Debug)]
 pub struct CircularArc {
     pub circle: Circle,
-    pub angle_a: f64,
-    pub angle_b: f64,
-    pub angle_c: f64,
+    pub angles: ArcAngles,
 }
 
 impl CircularArc {
-    pub fn new(circle: Circle, angle_a: f64, angle_b: f64, angle_c: f64) -> Self {
-        Self {
-            circle,
-            angle_a,
-            angle_b,
-            angle_c,
-        }
+    pub fn new(circle: Circle, angles: ArcAngles) -> Self {
+        Self { circle, angles }
     }
 }
 
 impl Geometry for CircularArc {}
 impl DirectedEdge for CircularArc {
     fn start(&self) -> Complex {
-        self.circle.get_point(self.angle_a)
+        let ArcAngles(a, _, _) = self.angles;
+        self.circle.get_point(a)
     }
 
     fn end(&self) -> Complex {
-        self.circle.get_point(self.angle_c)
+        let ArcAngles(_, _, c) = self.angles;
+        self.circle.get_point(c)
     }
 }
 
@@ -39,18 +34,8 @@ impl Display for CircularArc {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let CircularArc {
             circle: Circle { center, radius },
-            angle_a,
-            angle_b,
-            angle_c,
+            angles,
         } = self;
-        write!(
-            f,
-            "Arc(c={}, r={:.3}, {:.3}° -> {:.3}° -> {:.3}°)",
-            center,
-            radius,
-            angle_a.to_degrees(),
-            angle_b.to_degrees(),
-            angle_c.to_degrees()
-        )
+        write!(f, "Arc(c={}, r={:.3}, {})", center, radius, angles)
     }
 }

--- a/mobius/src/geometry/circular_arc.rs
+++ b/mobius/src/geometry/circular_arc.rs
@@ -20,13 +20,13 @@ impl CircularArc {
 impl Geometry for CircularArc {}
 impl DirectedEdge for CircularArc {
     fn start(&self) -> Complex {
-        let ArcAngles(a, _, _) = self.angles;
+        let ArcAngles(a, _) = self.angles;
         self.circle.get_point(a)
     }
 
     fn end(&self) -> Complex {
-        let ArcAngles(_, _, c) = self.angles;
-        self.circle.get_point(c)
+        let ArcAngles(_, b) = self.angles;
+        self.circle.get_point(b)
     }
 }
 

--- a/mobius/src/geometry/mod.rs
+++ b/mobius/src/geometry/mod.rs
@@ -1,3 +1,4 @@
+pub mod arc_angles;
 pub mod circle;
 pub mod circular_arc;
 pub mod double_ray;
@@ -7,6 +8,7 @@ pub mod ray;
 
 use crate::Complex;
 
+pub use arc_angles::*;
 pub use circle::*;
 pub use circular_arc::*;
 pub use double_ray::*;

--- a/mobius/src/hyperbolic_tilings.rs
+++ b/mobius/src/hyperbolic_tilings.rs
@@ -141,8 +141,7 @@ pub fn get_fundamental_region(
     let vertex = edge_circle.center + Complex::from_polar(edge_circle.radius, suppliment);
 
     let edge_bisector = LineSegment::new(center, edge_midpoint);
-    let angle_midpoint = (suppliment + PI) / 2.0;
-    let angles = ArcAngles::new(PI, angle_midpoint, suppliment).unwrap();
+    let angles = ArcAngles::new(PI, suppliment).unwrap();
     let edge = CircularArc::new(edge_circle, angles);
     let angle_bisector = LineSegment::new(vertex, center);
 

--- a/mobius/src/hyperbolic_tilings.rs
+++ b/mobius/src/hyperbolic_tilings.rs
@@ -3,7 +3,7 @@ use std::f64::consts::{FRAC_PI_2, PI, TAU};
 use abstraction::Group;
 
 use crate::{
-    geometry::{Circle, CircularArc, LineSegment},
+    geometry::{ArcAngles, Circle, CircularArc, LineSegment},
     isogonal::Isogonal,
     rotation,
     transformable::ClineArcTile,
@@ -126,7 +126,7 @@ pub fn get_fundamental_region(
     p: usize,
     q: usize,
 ) -> Result<(ClineArcTile, (Complex, Complex, Complex)), String> {
-    let (conj, r_conj, e2_conj) = reflection_group(p, q)?;
+    //let (conj, r_conj, e2_conj) = reflection_group(p, q)?;
 
     // tile center
     let center = Complex::Zero;
@@ -144,7 +144,8 @@ pub fn get_fundamental_region(
 
     let edge_bisector = LineSegment::new(center, edge_midpoint);
     let angle_midpoint = (suppliment + PI) / 2.0;
-    let edge = CircularArc::new(edge_circle, PI, angle_midpoint, suppliment);
+    let angles = ArcAngles::new(PI, angle_midpoint, suppliment)?;
+    let edge = CircularArc::new(edge_circle, angles);
     let angle_bisector = LineSegment::new(vertex, center);
 
     Ok((

--- a/mobius/src/hyperbolic_tilings.rs
+++ b/mobius/src/hyperbolic_tilings.rs
@@ -144,7 +144,7 @@ pub fn get_fundamental_region(
 
     let edge_bisector = LineSegment::new(center, edge_midpoint);
     let angle_midpoint = (suppliment + PI) / 2.0;
-    let angles = ArcAngles::new(PI, angle_midpoint, suppliment)?;
+    let angles = ArcAngles::new(PI, angle_midpoint, suppliment).unwrap();
     let edge = CircularArc::new(edge_circle, angles);
     let angle_bisector = LineSegment::new(vertex, center);
 

--- a/mobius/src/isogonal.rs
+++ b/mobius/src/isogonal.rs
@@ -1,4 +1,4 @@
-use std::ops::Mul;
+use std::{fmt::Display, ops::Mul};
 
 use abstraction::{Group, Semigroup};
 
@@ -75,6 +75,15 @@ impl Group for Isogonal {
             Self::Conformal(m) => Self::Conformal(m.inverse()),
             // (M conj)^-1 = conj^-1 M^-1 = conj(M)^-1 conj
             Self::AntiConformal(m) => Self::AntiConformal(m.complex_conjugate().inverse()),
+        }
+    }
+}
+
+impl Display for Isogonal {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Conformal(m) => write!(f, "Conformal{}", m),
+            Self::AntiConformal(m) => write!(f, "AntiConformal{}", m),
         }
     }
 }

--- a/mobius/src/lib.rs
+++ b/mobius/src/lib.rs
@@ -2,6 +2,7 @@ pub mod address;
 pub mod algorithms;
 pub mod cline_arc;
 mod complex;
+pub mod float_error;
 pub mod geometry;
 pub mod isogonal;
 mod mobius;

--- a/mobius/src/motifs/halloween.rs
+++ b/mobius/src/motifs/halloween.rs
@@ -122,9 +122,9 @@ pub fn candy_corn() -> (Motif, Vec<Style>) {
     let circle_a = Circle::new(center_a, radius);
     let circle_b = Circle::new(center_b, radius);
     let circle_c = Circle::new(center_c, radius);
-    let angles_a = ArcAngles::new(-FRAC_PI_3, 0.0, FRAC_PI_3).unwrap();
-    let angles_b = ArcAngles::new(FRAC_PI_3, 2.0 * FRAC_PI_3, PI).unwrap();
-    let angles_c = ArcAngles::new(-PI, -2.0 * FRAC_PI_3, -FRAC_PI_3).unwrap();
+    let angles_a = ArcAngles::new(-FRAC_PI_3, FRAC_PI_3).unwrap();
+    let angles_b = ArcAngles::new(FRAC_PI_3, PI).unwrap();
+    let angles_c = ArcAngles::new(-PI, -FRAC_PI_3).unwrap();
     let arc_a = CircularArc::new(circle_a, angles_a);
     let arc_b = CircularArc::new(circle_b, angles_b);
     let arc_c = CircularArc::new(circle_c, angles_c);
@@ -135,7 +135,7 @@ pub fn candy_corn() -> (Motif, Vec<Style>) {
     let radius2 = 2.0 * radius1;
     let circle1 = Circle::new(a, radius1);
     let circle2 = Circle::new(a, radius2);
-    let divider_angles = ArcAngles::new(5.0 * FRAC_PI_6, PI, 7.0 * FRAC_PI_6).unwrap();
+    let divider_angles = ArcAngles::new(5.0 * FRAC_PI_6, 7.0 * FRAC_PI_6).unwrap();
     let arc1 = CircularArc::new(circle1, divider_angles);
     let arc2 = CircularArc::new(circle2, divider_angles);
 
@@ -198,10 +198,10 @@ pub fn bone(length: f64) -> ClineArcTile {
     let circle_bottom_left = Circle::new(center_bottom_left, 1.0);
     let circle_bottom_right = Circle::new(center_bottom_right, 1.0);
 
-    let angles_top_left = ArcAngles::new(0.0, FRAC_PI_2, 3.0 * FRAC_PI_2).unwrap();
-    let angles_top_right = ArcAngles::new(-FRAC_PI_2, FRAC_PI_2, PI).unwrap();
-    let angles_bottom_left = ArcAngles::new(FRAC_PI_2, PI, TAU).unwrap();
-    let angles_bottom_right = ArcAngles::new(-PI, -FRAC_PI_2, FRAC_PI_2).unwrap();
+    let angles_top_left = ArcAngles::new(0.0, 3.0 * FRAC_PI_2).unwrap();
+    let angles_top_right = ArcAngles::new(-FRAC_PI_2, PI).unwrap();
+    let angles_bottom_left = ArcAngles::new(FRAC_PI_2, TAU).unwrap();
+    let angles_bottom_right = ArcAngles::new(-PI, FRAC_PI_2).unwrap();
     let arc_top_left = CircularArc::new(circle_top_left, angles_top_left);
     let arc_top_right = CircularArc::new(circle_top_right, angles_top_right);
     let arc_bottom_left = CircularArc::new(circle_bottom_left, angles_bottom_left);
@@ -245,11 +245,11 @@ pub fn witch_hat() -> Motif {
     let circle_point_top = Circle::new(Complex::new(1.0, 1.0), 2.0);
 
     // Outline the outside of the hat
-    let angles_brim_left = ArcAngles::new(FRAC_PI_2, 3.0 * FRAC_PI_4, PI).unwrap();
-    let angles_brim_bottom = ArcAngles::new(-PI, -FRAC_PI_2, 0.0).unwrap();
-    let angles_brim_right = ArcAngles::new(0.0, FRAC_PI_4, FRAC_PI_2).unwrap();
-    let angles_point_bottom = ArcAngles::new(PI, FRAC_PI_2, 0.0).unwrap();
-    let angles_point_top = ArcAngles::new(0.0, FRAC_PI_2, PI).unwrap();
+    let angles_brim_left = ArcAngles::new(FRAC_PI_2, PI).unwrap();
+    let angles_brim_bottom = ArcAngles::new(-PI, 0.0).unwrap();
+    let angles_brim_right = ArcAngles::new(0.0, FRAC_PI_2).unwrap();
+    let angles_point_bottom = ArcAngles::new(PI, 0.0).unwrap();
+    let angles_point_top = ArcAngles::new(0.0, PI).unwrap();
     let arc_brim_left = CircularArc::new(circle_brim_left, angles_brim_left);
     let arc_brim_bottom = CircularArc::new(circle_brim_bottom, angles_brim_bottom);
     let arc_brim_right = CircularArc::new(circle_brim_right, angles_brim_right);
@@ -268,7 +268,7 @@ pub fn witch_hat() -> Motif {
     let circle_band_top = Circle::new(Complex::new(0.0, 2.0), SQRT_2);
     let circle_band_bottom = Circle::new(Complex::I, SQRT_2);
 
-    let angles_band = ArcAngles::new(-FRAC_PI_4, -FRAC_PI_2, -3.0 * FRAC_PI_4).unwrap();
+    let angles_band = ArcAngles::new(-FRAC_PI_4, -3.0 * FRAC_PI_4).unwrap();
     let arc_band_top = CircularArc::new(circle_band_top, angles_band);
     let band_left = LineSegment::new(Complex::new(-1.0, 1.0), -Complex::ONE);
     let arc_band_bottom = CircularArc::new(circle_band_bottom, angles_band.reverse());
@@ -293,9 +293,9 @@ pub fn skull() -> ClineArcTile {
     let left_circle = Circle::new(-Complex::ONE, 1.0);
     let right_circle = Circle::new(Complex::ONE, 1.0);
 
-    let angles_top = ArcAngles::new(0.0, FRAC_PI_2, PI).unwrap();
-    let angles_left = ArcAngles::new(PI, 5.0 * FRAC_PI_4, 3.0 * FRAC_PI_2).unwrap();
-    let angles_right = ArcAngles::new(-FRAC_PI_2, -FRAC_PI_4, 0.0).unwrap();
+    let angles_top = ArcAngles::new(0.0, PI).unwrap();
+    let angles_left = ArcAngles::new(PI, 3.0 * FRAC_PI_2).unwrap();
+    let angles_right = ArcAngles::new(-FRAC_PI_2, 0.0).unwrap();
     let arc_top = CircularArc::new(top_circle, angles_top);
     let arc_left = CircularArc::new(left_circle, angles_left);
     let arc_right = CircularArc::new(right_circle, angles_right);

--- a/mobius/src/nearly.rs
+++ b/mobius/src/nearly.rs
@@ -10,3 +10,10 @@ pub fn is_nearly(a: f64, b: f64) -> bool {
         diff <= EPSILON * a.abs().max(b.abs())
     }
 }
+
+#[cfg(test)]
+pub fn assert_nearly(a: f64, b: f64) {
+    if !is_nearly(a, b) {
+        panic!("!is_nearly({}, {})", a, b);
+    }
+}

--- a/mobius/src/rendering/mod.rs
+++ b/mobius/src/rendering/mod.rs
@@ -1,9 +1,11 @@
 pub mod render_primitive;
 pub mod style;
 
+use std::error::Error;
+
 pub use render_primitive::*;
 pub use style::*;
 
 pub trait Renderable {
-    fn bake_geometry(&self) -> Vec<RenderPrimitive>;
+    fn bake_geometry(&self) -> Result<Vec<RenderPrimitive>, Box<dyn Error>>;
 }

--- a/mobius/src/svg_plot.rs
+++ b/mobius/src/svg_plot.rs
@@ -7,7 +7,7 @@ use svg::{
 };
 
 use crate::{
-    geometry::{Circle, CircularArc, LineSegment},
+    geometry::{ArcAngles, Circle, CircularArc, LineSegment},
     rendering::{RenderPrimitive, Renderable, Style},
     transformable::{Cline, ClineTile, Motif},
     Complex,
@@ -27,10 +27,9 @@ fn svg_circle(circle: Circle) -> Box<dyn Node> {
 fn svg_circular_arc(arc: CircularArc) -> Box<dyn Node> {
     let CircularArc {
         circle: Circle { center, radius },
-        angle_a: start_angle,
-        angle_c: end_angle,
-        ..
+        angles,
     } = arc;
+    let ArcAngles(start_angle, _, end_angle) = angles;
 
     let start = center + Complex::from_polar(radius, start_angle);
     let start_x = start.real();

--- a/mobius/src/svg_plot.rs
+++ b/mobius/src/svg_plot.rs
@@ -1,8 +1,5 @@
 use core::f64;
-use std::{
-    f64::consts::{PI, TAU},
-    path,
-};
+use std::{f64::consts::PI, path};
 
 use svg::{
     node::element::{path::Data, Circle as SvgCircle, Group, Line as SvgLine, Path, Rectangle},
@@ -36,7 +33,9 @@ fn svg_circular_arc(arc: CircularArc) -> Box<dyn Node> {
     let start_y = start.imag();
 
     let counterclockwise = angles.direction() == ArcDirection::Counterclockwise;
-    let large_arc = (end_angle - start_angle).rem_euclid(TAU) > PI;
+    // ArcAngles guarantees that the total angle of the arc is in [0, 2pi). If it's
+    // greater than pi in magnitude, we want to stroke the long way around the circle.
+    let large_arc = (end_angle - start_angle).abs() > PI;
 
     let end = arc.end();
     let end_x = end.real();

--- a/mobius/src/svg_plot.rs
+++ b/mobius/src/svg_plot.rs
@@ -107,12 +107,8 @@ impl From<Vec<SvgNode>> for SvgNodes {
 
 impl<T: Renderable> From<&T> for SvgNodes {
     fn from(value: &T) -> Self {
-        let nodes: Vec<SvgNode> = value
-            .bake_geometry()
-            .iter()
-            .map(|x| SvgNode::from(*x))
-            .collect();
-
+        let baked = value.bake_geometry().unwrap();
+        let nodes: Vec<SvgNode> = baked.iter().map(|x| SvgNode::from(*x)).collect();
         nodes.into()
     }
 }

--- a/mobius/src/transformable/cline.rs
+++ b/mobius/src/transformable/cline.rs
@@ -1,4 +1,4 @@
-use std::fmt::Display;
+use std::{error::Error, fmt::Display};
 
 use crate::{
     geometry::{Circle, Line},
@@ -229,13 +229,13 @@ impl Transformable<Isogonal> for Cline {
 }
 
 impl Renderable for Cline {
-    fn bake_geometry(&self) -> Vec<RenderPrimitive> {
+    fn bake_geometry(&self) -> Result<Vec<RenderPrimitive>, Box<dyn Error>> {
         let primitive = match self.classify() {
             GeneralizedCircle::Circle(circle) => RenderPrimitive::Circle(circle),
             GeneralizedCircle::Line(line) => RenderPrimitive::make_line(line),
         };
 
-        vec![primitive]
+        Ok(vec![primitive])
     }
 }
 

--- a/mobius/src/transformable/cline.rs
+++ b/mobius/src/transformable/cline.rs
@@ -239,6 +239,13 @@ impl Renderable for Cline {
     }
 }
 
+impl Display for Cline {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let &Self { a, b, c, d } = self;
+        write!(f, "[{} {}]\n[{} {}]", a, b, c, d)
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;


### PR DESCRIPTION
This PR:

- Applies ["Parse, don't validate"](https://lexi-lambda.github.io/blog/2019/11/05/parse-don-t-validate/) to the 3 angles used to create a circular arc. I made an `ArcAngles` type to implement this
- After doing that, I found that some of the existing examples were failing. I traced it down, it doesn't have to do with the angles themselves, but rather some of the computed clines have floating point rounding error that causes some of the values to become ridiculously large.
- Since fixing numerical stability issues is something I need to read up more on (and certainly beyond scope here) I applied a mitigation: Detect the errors with a custom `Error` type, and when transforming primitives, filter bad primitives out of the list and print a warning for now until I know how to address the problem. This way, I still can produce the artworks.