### PR TITLE
Use thiserror for easier errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,6 +138,7 @@ dependencies = [
  "pretty_assertions",
  "svg",
  "test-case",
+ "thiserror",
 ]
 
 [[package]]
@@ -189,9 +190,9 @@ checksum = "94afda9cd163c04f6bee8b4bf2501c91548deae308373c436f36aeff3cf3c4a3"
 
 [[package]]
 name = "syn"
-version = "2.0.79"
+version = "2.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89132cd0bf050864e1d38dc3bbc07a0eb8e7530af26344d3d2bbbef83499f590"
+checksum = "25aa4ce346d03a6dcd68dd8b4010bcb74e54e62c90c573f394c46eae99aba32d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -229,6 +230,26 @@ dependencies = [
  "quote",
  "syn",
  "test-case-core",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c006c85c7651b3cf2ada4584faa36773bd07bac24acfb39f3c431b36d7e667aa"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f077553d607adc1caf65430528a576c757a71ed73944b66ebb58ef2bbd243568"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/mobius/Cargo.toml
+++ b/mobius/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 abstraction = { path = "../abstraction" }
 svg = "0.18.0"
+thiserror = "2.0.3"
 
 [dev-dependencies]
 clap = { version = "4.5.20", features = ["derive"] }

--- a/mobius/src/cline_arc.rs
+++ b/mobius/src/cline_arc.rs
@@ -1,4 +1,4 @@
-use std::{error::Error, fmt::Display};
+use std::fmt::Display;
 
 use crate::{
     geometry::{
@@ -10,30 +10,6 @@ use crate::{
     transformable::{Cline, Transformable},
     Complex,
 };
-
-#[derive(Debug)]
-pub enum ClineArcError {
-    // To reduce the size of the enum, the first parameter is a pretty-printed
-    // string representation of the cline such that you can see the numeric
-    // values for debugging
-    PossiblePrecisionError(String, Box<dyn Error + 'static>),
-}
-
-impl Display for ClineArcError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::PossiblePrecisionError(cline_formatted, inner_error) => {
-                write!(
-                    f,
-                    "possible precision issue for ClineArc:\n{}\ncaused by: {}",
-                    cline_formatted, inner_error
-                )
-            }
-        }
-    }
-}
-
-impl Error for ClineArcError {}
 
 #[derive(Clone, Copy, Debug)]
 pub enum ClineArcGeometry {

--- a/mobius/src/complex_error.rs
+++ b/mobius/src/complex_error.rs
@@ -1,10 +1,12 @@
-use std::{error::Error, fmt::Display};
+use thiserror::Error;
 
 use crate::Complex;
 
-#[derive(Debug)]
+#[derive(Debug, Error)]
 pub enum ComplexError {
+    #[error("value must be finite: {0} = {1}")]
     NotFinite(String, Complex),
+    #[error("value must be finite and non-zero: {0} = {1}")]
     NotFiniteNonzero(String, Complex),
 }
 
@@ -27,16 +29,3 @@ impl ComplexError {
         }
     }
 }
-
-impl Display for ComplexError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::NotFinite(var, val) => write!(f, "value must be finite: {} = {}", var, val),
-            Self::NotFiniteNonzero(var, val) => {
-                write!(f, "value must be finite and non-zero: {} = {}", var, val)
-            }
-        }
-    }
-}
-
-impl Error for ComplexError {}

--- a/mobius/src/float_error.rs
+++ b/mobius/src/float_error.rs
@@ -1,7 +1,8 @@
-use std::{error::Error, fmt::Display};
+use thiserror::Error;
 
-#[derive(Debug)]
+#[derive(Debug, Error)]
 pub enum FloatError {
+    #[error("value must be finite: {0} = {1}")]
     NonFinite(String, f64),
 }
 
@@ -15,13 +16,3 @@ impl FloatError {
         }
     }
 }
-
-impl Display for FloatError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::NonFinite(var, val) => write!(f, "value must be finite: {} = {}", var, val),
-        }
-    }
-}
-
-impl Error for FloatError {}

--- a/mobius/src/geometry/arc_angles.rs
+++ b/mobius/src/geometry/arc_angles.rs
@@ -1,42 +1,21 @@
 use std::{
-    error::Error,
     f64::consts::{PI, TAU},
     fmt::Display,
 };
 
+use thiserror::Error;
+
 use crate::{float_error::FloatError, interpolation::lerp, nearly::is_nearly};
 
-#[derive(Debug)]
+#[derive(Debug, Error)]
 pub enum ArcAnglesParseError {
-    /// One of the input floats is not valid
-    BadFloat(FloatError),
-    /// Arc angles must be distinct
+    #[error("{0}")]
+    BadFloat(#[from] FloatError),
+    #[error("arc angles must be distinct: {0}")]
     DegenerateArc(f64),
-    /// Arc is bigger than a full circle. I'm not supporting this case
+    #[error("only arcs smaller than a full circle are supported: ({0}, {1})")]
     BigArcNotSupported(f64, f64),
 }
-
-impl Display for ArcAnglesParseError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::BadFloat(err) => err.fmt(f),
-            Self::DegenerateArc(a) => write!(f, "arc angles must be distinct: ({}, {})", a, a),
-            Self::BigArcNotSupported(a, b) => write!(
-                f,
-                "only arcs smaller than a full circle are supported: ({}, {})",
-                a, b
-            ),
-        }
-    }
-}
-
-impl From<FloatError> for ArcAnglesParseError {
-    fn from(value: FloatError) -> Self {
-        Self::BadFloat(value)
-    }
-}
-
-impl Error for ArcAnglesParseError {}
 
 #[derive(Clone, Copy, PartialEq, Debug)]
 pub enum ArcDirection {

--- a/mobius/src/geometry/arc_angles.rs
+++ b/mobius/src/geometry/arc_angles.rs
@@ -97,7 +97,7 @@ impl ArcAngles {
     /// Compute the absolute angular difference between the two end points.
     pub fn central_angle(&self) -> f64 {
         let Self(a, b) = self;
-        return (b - a).abs();
+        (b - a).abs()
     }
 
     pub fn direction(&self) -> ArcDirection {

--- a/mobius/src/geometry/circular_arc.rs
+++ b/mobius/src/geometry/circular_arc.rs
@@ -1,35 +1,18 @@
-use std::{error::Error, fmt::Display};
+use std::fmt::Display;
+
+use thiserror::Error;
 
 use crate::Complex;
 
 use super::{circle::Circle, ArcAngles, ArcAnglesParseError, ArcDirection, DirectedEdge, Geometry};
 
-#[derive(Debug)]
+#[derive(Debug, Error)]
 pub enum CircularArcError {
-    BadAngles(ArcAnglesParseError),
+    #[error("{0}")]
+    BadAngles(#[from] ArcAnglesParseError),
+    #[error("duplicate point: {0}")]
     DuplicatePoint(Complex),
-    PointAtCenter(Complex),
 }
-
-impl Display for CircularArcError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            CircularArcError::BadAngles(err) => err.fmt(f),
-            CircularArcError::DuplicatePoint(point) => write!(f, "Duplicate point: {}", point),
-            CircularArcError::PointAtCenter(point) => {
-                write!(f, "Point at center of circle not allowed: {}", point)
-            }
-        }
-    }
-}
-
-impl From<ArcAnglesParseError> for CircularArcError {
-    fn from(value: ArcAnglesParseError) -> Self {
-        Self::BadAngles(value)
-    }
-}
-
-impl Error for CircularArcError {}
 
 // Directed circular arc through 3 points on a circular arc
 #[derive(PartialEq, Clone, Copy, Debug)]

--- a/mobius/src/geometry/line.rs
+++ b/mobius/src/geometry/line.rs
@@ -1,45 +1,20 @@
-use std::{error::Error, fmt::Display};
+use std::fmt::Display;
+
+use thiserror::Error;
 
 use crate::{complex_error::ComplexError, float_error::FloatError, nearly::is_nearly, Complex};
 
 use super::{Geometry, LineSegment};
 
-#[derive(Debug)]
+#[derive(Debug, Error)]
 pub enum LineError {
-    InvalidComplexParam(ComplexError),
-    InvalidFloatParam(FloatError),
-    /// Tried to create a line with two identical points
-    /// this specifies a point, not a point
+    #[error("{0}")]
+    InvalidComplexParam(#[from] ComplexError),
+    #[error("{0}")]
+    InvalidFloatParam(#[from] FloatError),
+    #[error("a and b must be distinct points: {0}")]
     DuplicatePoints(Complex),
 }
-
-impl From<ComplexError> for LineError {
-    fn from(value: ComplexError) -> Self {
-        Self::InvalidComplexParam(value)
-    }
-}
-
-impl From<FloatError> for LineError {
-    fn from(value: FloatError) -> Self {
-        Self::InvalidFloatParam(value)
-    }
-}
-
-impl Display for LineError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            LineError::InvalidComplexParam(complex_error) => complex_error.fmt(f),
-            LineError::InvalidFloatParam(float_error) => float_error.fmt(f),
-            LineError::DuplicatePoints(complex) => write!(
-                f,
-                "a and b must be distinct points, got {}, {}",
-                complex, complex
-            ),
-        }
-    }
-}
-
-impl Error for LineError {}
 
 #[derive(Clone, Copy, Debug)]
 pub struct Line {


### PR DESCRIPTION
Originally I was manually creating error types to see how that works. Pretty neat, but lots of boilerplate. I see why people use `thiserror` to simplify things.