### PR TITLE
Add a UnitComplex type to represent unit vectors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,6 +108,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
+name = "derive_more"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "unicode-xid",
+]
+
+[[package]]
 name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -135,6 +156,7 @@ version = "0.1.0"
 dependencies = [
  "abstraction",
  "clap",
+ "derive_more",
  "pretty_assertions",
  "svg",
  "test-case",
@@ -257,6 +279,12 @@ name = "unicode-ident"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "utf8parse"

--- a/mobius/Cargo.toml
+++ b/mobius/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 abstraction = { path = "../abstraction" }
 svg = "0.18.0"
 thiserror = "2.0.3"
+derive_more = { version = "1.0.0", features = ["display"] }
 
 [dev-dependencies]
 clap = { version = "4.5.20", features = ["derive"] }

--- a/mobius/src/complex.rs
+++ b/mobius/src/complex.rs
@@ -102,19 +102,6 @@ impl Complex {
         }
     }
 
-    // Normalize the vector. This may return None when this operation is
-    // not defined (e.g. 0 / 0 and inf / inf are undefined)
-    pub fn normalize(&self) -> Option<Self> {
-        match self {
-            Complex::Zero => None,
-            Complex::Infinity => None,
-            Complex::Finite(a, b) => {
-                let r = self.mag();
-                Some(Complex::Finite(a / r, b / r))
-            }
-        }
-    }
-
     pub fn inverse(&self) -> Self {
         match self {
             Complex::Zero => Complex::Infinity,

--- a/mobius/src/geometry/ray.rs
+++ b/mobius/src/geometry/ray.rs
@@ -1,11 +1,11 @@
-use crate::Complex;
+use crate::{unit_complex::UnitComplex, Complex};
 
 use super::{DirectedEdge, Geometry};
 
 #[derive(PartialEq, Clone, Copy, Debug)]
 pub struct Ray {
     pub start: Complex,
-    pub unit_dir: Complex,
+    pub unit_dir: UnitComplex,
 }
 
 impl Geometry for Ray {}

--- a/mobius/src/lib.rs
+++ b/mobius/src/lib.rs
@@ -15,6 +15,7 @@ mod recipes;
 pub mod rendering;
 pub mod svg_plot;
 pub mod transformable;
+pub mod unit_complex;
 
 pub mod hyperbolic_tilings;
 

--- a/mobius/src/orthogonal_arcs.rs
+++ b/mobius/src/orthogonal_arcs.rs
@@ -90,7 +90,7 @@ pub enum OrthogonalArc {
 
 #[cfg(test)]
 mod test {
-    use crate::geometry::Line;
+    use crate::{geometry::Line, unit_complex::UnitComplex};
 
     use super::*;
     use test_case::test_case;
@@ -119,8 +119,8 @@ mod test {
         }
     }
 
-    #[test_case(0.0, PI, Line::new(-Complex::I, -2.0).unwrap(); "diameter at 0 and pi")]
-    #[test_case(PI / 2.0, -PI / 2.0, Line::new(-Complex::ONE, -1.0).unwrap(); "diameter at pi/2 and -pi/2")]
+    #[test_case(0.0, PI, Line::new(-UnitComplex::I, -2.0).unwrap(); "diameter at 0 and pi")]
+    #[test_case(PI / 2.0, -PI / 2.0, Line::new(-UnitComplex::ONE, -1.0).unwrap(); "diameter at pi/2 and -pi/2")]
     pub fn compute_orthog_circle_with_points_on_diameter_computes_line(
         a: f64,
         b: f64,

--- a/mobius/src/rendering/render_primitive.rs
+++ b/mobius/src/rendering/render_primitive.rs
@@ -17,7 +17,7 @@ impl RenderPrimitive {
     /// Render a ray as a line segment from the start point to far off the canvas.
     pub fn make_ray(ray: Ray) -> Self {
         let Ray { start, unit_dir } = ray;
-        let end = unit_dir * FAR_AWAY.into();
+        let end = *unit_dir.get() * FAR_AWAY.into();
 
         Self::LineSegment(LineSegment { start, end })
     }
@@ -29,8 +29,8 @@ impl RenderPrimitive {
         } = line;
 
         let far_away: Complex = FAR_AWAY.into();
-        let tangent = Complex::I * unit_normal;
-        let center: Complex = unit_normal * distance.into();
+        let &tangent = unit_normal.rot90().get();
+        let center: Complex = *unit_normal.get() * distance.into();
         let start: Complex = center + tangent * far_away;
         let end: Complex = center - tangent * far_away;
 

--- a/mobius/src/unit_complex.rs
+++ b/mobius/src/unit_complex.rs
@@ -44,3 +44,84 @@ impl Neg for UnitComplex {
         Self(-self.0)
     }
 }
+
+#[cfg(test)]
+mod test {
+    use std::f64::consts::PI;
+
+    use super::*;
+
+    #[test]
+    pub fn normalize_with_zero_returns_error() {
+        let result = UnitComplex::normalize(Complex::Zero);
+
+        assert!(matches!(result, Err(ComplexError::NotFiniteNonzero(_, _))))
+    }
+
+    #[test]
+    pub fn normalize_with_infinity_returns_error() {
+        let result = UnitComplex::normalize(Complex::Infinity);
+
+        assert!(matches!(result, Err(ComplexError::NotFiniteNonzero(_, _))))
+    }
+
+    #[test]
+    pub fn normalize_with_valid_complex_normalizes_result() -> Result<(), ComplexError> {
+        let result = UnitComplex::normalize(Complex::new(3.0, 4.0))?;
+
+        let expected = UnitComplex::normalize(Complex::new(3.0 / 5.0, 4.0 / 5.0))?;
+        assert_eq!(result, expected);
+        Ok(())
+    }
+
+    #[test]
+    pub fn from_angle_computes_correct_direction() -> Result<(), ComplexError> {
+        let result = UnitComplex::from_angle(4.0 * PI / 6.0);
+
+        // cos(4pi/6) = -1/2
+        // sin(4pi/6) = sqrt(3)/2
+        let z = Complex::new(-0.5, 0.5 * (3.0f64).sqrt());
+        let expected = UnitComplex::normalize(z)?;
+        assert_eq!(result, expected);
+        Ok(())
+    }
+
+    #[test]
+    pub fn rot90_rotates_vector_ccw() {
+        let n = UnitComplex::from_angle(PI / 4.0);
+
+        let result = n.rot90();
+
+        let expected = UnitComplex::from_angle(3.0 * PI / 4.0);
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    pub fn rot90_has_order_4() {
+        let n = UnitComplex::from_angle(PI / 3.0);
+
+        let result = n.rot90().rot90().rot90().rot90();
+
+        assert_eq!(result, n);
+    }
+
+    #[test]
+    pub fn neg_negates_components() {
+        let n = UnitComplex::from_angle(PI / 6.0);
+
+        let result = -n;
+
+        let expected = UnitComplex::from_angle(7.0 * PI / 6.0);
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    pub fn rot90_twice_same_as_neg() {
+        let n = UnitComplex::from_angle(PI / 6.0);
+
+        let rot180 = n.rot90().rot90();
+        let neg = -n;
+
+        assert_eq!(rot180, neg);
+    }
+}

--- a/mobius/src/unit_complex.rs
+++ b/mobius/src/unit_complex.rs
@@ -1,0 +1,46 @@
+use std::ops::Neg;
+
+use crate::{complex_error::ComplexError, Complex};
+
+#[derive(PartialEq, Clone, Copy, Debug, derive_more::Display)]
+pub struct UnitComplex(Complex);
+
+impl UnitComplex {
+    pub const I: Self = Self(Complex::I);
+    pub const ONE: Self = Self(Complex::ONE);
+
+    pub fn normalize(z: Complex) -> Result<Self, ComplexError> {
+        ComplexError::require_finite_nonzero("z", z)?;
+        let a = z.real();
+        let b = z.imag();
+        let r = z.mag();
+        Ok(Self(Complex::Finite(a / r, b / r)))
+    }
+
+    /// A unit complex number can be determined uniquely by an angle
+    pub fn from_angle(theta: f64) -> Self {
+        Self(Complex::from_polar(1.0, theta))
+    }
+
+    /// Rotate the complex number a quarter turn counterclockwise. This
+    /// is used to compute a normal from a tangent
+    pub fn rot90(&self) -> Self {
+        let &Self(z) = self;
+        let a = z.real();
+        let b = z.imag();
+
+        Self(Complex::new(-b, a))
+    }
+
+    pub fn get(&self) -> &Complex {
+        &self.0
+    }
+}
+
+impl Neg for UnitComplex {
+    type Output = Self;
+
+    fn neg(self) -> Self::Output {
+        Self(-self.0)
+    }
+}

--- a/mobius/src/unit_complex.rs
+++ b/mobius/src/unit_complex.rs
@@ -2,6 +2,7 @@ use std::ops::Neg;
 
 use crate::{complex_error::ComplexError, Complex};
 
+/// A complex number restricted so |z| = 1
 #[derive(PartialEq, Clone, Copy, Debug, derive_more::Display)]
 pub struct UnitComplex(Complex);
 
@@ -9,6 +10,8 @@ impl UnitComplex {
     pub const I: Self = Self(Complex::I);
     pub const ONE: Self = Self(Complex::ONE);
 
+    /// Constructor that takes a finite, nonzero complex number and
+    /// normalizes it so it has magnitude 1.
     pub fn normalize(z: Complex) -> Result<Self, ComplexError> {
         ComplexError::require_finite_nonzero("z", z)?;
         let a = z.real();
@@ -32,6 +35,7 @@ impl UnitComplex {
         Self(Complex::new(-b, a))
     }
 
+    /// Get the underlying complex number
     pub fn get(&self) -> &Complex {
         &self.0
     }


### PR DESCRIPTION
I realized something - `z.normalize()` is usually expressed as an operation on a complex number (or vector in general). but you could phrase it differently - you could think of it as a _constructor_ for a unit vector type. This means you bake the fact that it has unit length into the type at compile time, so less things to validate later.